### PR TITLE
给表格组件增加嵌套表头

### DIFF
--- a/examples/routers/table.vue
+++ b/examples/routers/table.vue
@@ -37,7 +37,35 @@
                         render (row, column, index) {
                             return `<i-button type="primary" size="small" @click="show(${index})">{{ info }}查看</i-button> <i-button type="error" size="small" @click="remove(${index})">删除</i-button>`;
                         }
-                    }
+                    },
+                    {
+                        title: '测试',
+                        children: [
+                            {
+                                title: '测试2',
+                                children: [
+                                {
+                                    title: '测试4',
+                                    children: [
+                                    {title: '测试5'},
+                                    {
+                                        title: '测试6',
+                                        children: [
+                                        {title: '测试7'}
+                                        ]
+                                    }
+                                    ]
+                                },
+                                {
+                                    title: '测试3'
+                                }
+                                ]
+                            },
+                            {
+                                title: '测试3'
+                            }
+                        ]
+                    },
                 ],
                 data6: [
                     {

--- a/src/components/table/table-head.vue
+++ b/src/components/table/table-head.vue
@@ -4,21 +4,24 @@
             <col v-for="(column, index) in columns" :width="setCellWidth(column, index, true)">
         </colgroup>
         <thead>
-            <tr>
-                <th v-for="(column, index) in columns" :class="alignCls(column)">
+            <tr v-for="row in rows">
+                <th
+                    v-for="column in row" :class="alignCls(column)"
+                    :rowspan="column.children.length > 0 ? 1 : rows.length - column.__depth"
+                    :colspan="column.__maxChildrenNum">
                     <div :class="cellClasses(column)">
                         <template v-if="column.type === 'selection'"><Checkbox :value="isSelectAll" @on-change="selectAll"></Checkbox></template>
                         <template v-else>
-                            <span v-html="renderHeader(column, index)"></span>
+                            <span v-html="renderHeader(column, column._index)"></span>
                             <span :class="[prefixCls + '-sort']" v-if="column.sortable">
-                                <i class="ivu-icon ivu-icon-arrow-up-b" :class="{on: column._sortType === 'asc'}" @click="handleSort(index, 'asc')"></i>
-                                <i class="ivu-icon ivu-icon-arrow-down-b" :class="{on: column._sortType === 'desc'}" @click="handleSort(index, 'desc')"></i>
+                                <i class="ivu-icon ivu-icon-arrow-up-b" :class="{on: column._sortType === 'asc'}" @click="handleSort(column._index, 'asc')"></i>
+                                <i class="ivu-icon ivu-icon-arrow-down-b" :class="{on: column._sortType === 'desc'}" @click="handleSort(column._index, 'desc')"></i>
                             </span>
                             <Poptip
                                 v-if="isPopperShow(column)"
                                 v-model="column._filterVisible"
                                 placement="bottom"
-                                @on-popper-hide="handleFilterHide(index)">
+                                @on-popper-hide="handleFilterHide(column._index)">
                                 <span :class="[prefixCls + '-filter']">
                                     <i class="ivu-icon ivu-icon-funnel" :class="{on: column._isFiltered}"></i>
                                 </span>
@@ -29,19 +32,19 @@
                                         </checkbox-group>
                                     </div>
                                     <div :class="[prefixCls + '-filter-footer']">
-                                        <i-button type="text" size="small" :disabled="!column._filterChecked.length" @click.native="handleFilter(index)">{{ t('i.table.confirmFilter') }}</i-button>
-                                        <i-button type="text" size="small" @click.native="handleReset(index)">{{ t('i.table.resetFilter') }}</i-button>
+                                        <i-button type="text" size="small" :disabled="!column._filterChecked.length" @click.native="handleFilter(column._index)">{{ t('i.table.confirmFilter') }}</i-button>
+                                        <i-button type="text" size="small" @click.native="handleReset(column._index)">{{ t('i.table.resetFilter') }}</i-button>
                                     </div>
                                 </div>
                                 <div slot="content" :class="[prefixCls + '-filter-list']" v-else>
                                     <ul :class="[prefixCls + '-filter-list-single']">
                                         <li
                                             :class="itemAllClasses(column)"
-                                            @click="handleReset(index)">{{ t('i.table.clearFilter') }}</li>
+                                            @click="handleReset(column._index)">{{ t('i.table.clearFilter') }}</li>
                                         <li
                                             :class="itemClasses(column, item)"
                                             v-for="item in column.filters"
-                                            @click="handleSelect(index, item.value)">{{ item.label }}</li>
+                                            @click="handleSelect(column._index, item.value)">{{ item.label }}</li>
                                     </ul>
                                 </div>
                             </Poptip>
@@ -65,6 +68,7 @@
         mixins: [ Mixin, Locale ],
         components: { CheckboxGroup, Checkbox, Poptip, iButton },
         props: {
+            headRows: Array,
             prefixCls: String,
             styleObject: Object,
             columns: Array,
@@ -77,6 +81,9 @@
             }
         },
         computed: {
+            rows () {
+                return this.headRows || [this.columns];
+            },
             styles () {
                 const style = Object.assign({}, this.styleObject);
                 const width = this.$parent.bodyHeight === 0 ? parseInt(this.styleObject.width) : parseInt(this.styleObject.width) + this.$parent.scrollBarWidth;

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -729,7 +729,6 @@
                     let makeColumns = this.makeColumns();
                     this.cloneColumns = makeColumns.columns;
                     this.headRows = makeColumns.headRows;
-                    console.log(this.headRows);
                     this.rebuildData = this.makeDataWithSortAndFilter();
                     this.handleResize();
                 },


### PR DESCRIPTION
colums 可以增加 children 字段实现复杂的表头，例如
```js
[
    {
        title: '测试',
        children: [
            {
                title: '测试2',
                children: [
                {
                    title: '测试4',
                    children: [
                    {title: '测试5'},
                    {
                        title: '测试6',
                        children: [
                        {title: '测试7'}
                        ]
                    }
                    ]
                },
                {
                    title: '测试3'
                }
                ]
            },
            {
                title: '测试3'
            }
        ]
    },
]
```
![tim 20170326180513](https://cloud.githubusercontent.com/assets/7115690/24330367/f6c9687e-124e-11e7-83fb-589c25545878.png)

针对官方文档中的示例代码（只有一层head）测试也没问题。在嵌套表头的时候，固定某列功能可能会显示不愉快。