### PR TITLE
修复表格宽度很多情况下计算不准确问题

### DIFF
--- a/src/components/table/mixin.js
+++ b/src/components/table/mixin.js
@@ -21,7 +21,7 @@ export default {
             let width = '';
             if (column.width) {
                 width = column.width;
-            } else if (this.columnsWidth[column._index]) {
+            } else if (this.columnsWidth[column._index] && column.width == 0) {
                 width = this.columnsWidth[column._index].width;
             }
             // when browser has scrollBar,set a width to resolve scroll position bug

--- a/src/components/table/table-body.vue
+++ b/src/components/table/table-body.vue
@@ -1,5 +1,5 @@
 <template>
-    <table cellspacing="0" cellpadding="0" border="0" :style="styleObject">
+    <table cellspacing="0" cellpadding="0" border="0">
         <colgroup>
             <col v-for="(column, index) in columns" :width="setCellWidth(column, index, false)">
         </colgroup>

--- a/src/components/table/table-head.vue
+++ b/src/components/table/table-head.vue
@@ -1,5 +1,5 @@
 <template>
-    <table cellspacing="0" cellpadding="0" border="0" :style="styles">
+    <table cellspacing="0" cellpadding="0" border="0">
         <colgroup>
             <col v-for="(column, index) in columns" :width="setCellWidth(column, index, true)">
         </colgroup>

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -655,8 +655,8 @@
         },
         created () {
             if (!this.context) this.currentContext = this.$parent;
-            this.showSlotHeader = this.$refs.title !== undefined;
-            this.showSlotFooter = this.$refs.footer !== undefined;
+            this.showSlotHeader = this.$slots.title !== undefined;
+            this.showSlotFooter = this.$slots.footer !== undefined;
             this.rebuildData = this.makeDataWithSortAndFilter();
         },
         mounted () {

--- a/src/styles/components/table.less
+++ b/src/styles/components/table.less
@@ -59,8 +59,8 @@
     }
 
     &-title, &-footer{
-        height: 48px;
-        line-height: 48px;
+        //height: 48px;
+        //line-height: 48px;
         border-bottom: 1px solid @border-color-split;
     }
     &-footer{

--- a/src/styles/components/table.less
+++ b/src/styles/components/table.less
@@ -122,7 +122,7 @@
     }
 
     & table{
-        //width: 100%;
+        width: 100%;
         table-layout: fixed;
     }
     &-border{


### PR DESCRIPTION
原来表格宽度是通过计算写死的，很多情况下并不能准确计算出正确的当前显示宽度，如有侧边栏时。将之改成100%显示解决。
并将计算表格宽度默认不计算使之为自动，如需要计算只要宽度设置0即可，这样解决了组件计算宽度不准的问题导致表格出现滚动条，很多时候是希望100%显示的，如确有需要也可以设置一个固定的width宽度。