### PR TITLE
让table支持在modal中正确显示

### DIFF
--- a/examples/routers/modal.vue
+++ b/examples/routers/modal.vue
@@ -1,8 +1,12 @@
 <template>
     <div>
-        <Button type="primary" @click="modal1 = true">显示对话框</Button>
+        <Button type="primary" @click="modal0 = true">显示对话框</Button>
+        <Button type="primary" @click="modal1 = true">表格嵌套1</Button>
+        <Button type="primary" @click="modal2 = true">表格嵌套2</Button>
+        <Button type="primary" @click="modal3 = true">表格嵌套3</Button>
+        <Button type="primary" @click="modal4 = true">表格嵌套4</Button>
         <Modal
-                v-model="modal1"
+                v-model="modal0"
                 title="普通的Modal对话框标题"
                 @on-ok="ok"
                 @on-cancel="cancel">
@@ -10,13 +14,267 @@
             <p>对话框内容</p>
             <p>对话框内容</p>
         </Modal>
+        <Modal v-model="modal1" title="对话框中嵌套表格">
+            <Table :modal="modal1" :columns="columns1" :data="data1"></Table>
+        </Modal>
+        <Modal v-model="modal2" title="对话框中嵌套表格">
+            <Table :modal="modal2" height="200" :columns="columns2" :data="data2"></Table>
+        </Modal>
+        <Modal v-model="modal3" title="对话框中嵌套表格">
+            <Table :modal="modal3" border :columns="columns3" :data="data3"></Table>
+        </Modal>
+        <Modal v-model="modal4" title="对话框中嵌套表格">
+            <Table :modal="modal4" ref="abc" height="200" border :columns="columns3" :data="data4"></Table>
+        </Modal>
+
+        <Table :columns="columns1" :data="data1"></Table>
+
     </div>
 </template>
 <script>
     export default {
         data () {
             return {
-                modal1: false
+                modal0: false,
+                modal1: false,
+                modal2: false,
+                modal3: false,
+                modal4: false,
+                modal5: false,
+                columns1: [
+                    {
+                        title: '姓名',
+                        key: 'name'
+                    },
+                    {
+                        title: '年龄',
+                        key: 'age'
+                    },
+                    {
+                        title: '地址',
+                        key: 'address'
+                    }
+                ],
+                data1: [
+                    {
+                        name: '王小明',
+                        age: 18,
+                        address: '北京市朝阳区芍药居'
+                    },
+                    {
+                        name: '张小刚',
+                        age: 25,
+                        address: '北京市海淀区西二旗'
+                    },
+                    {
+                        name: '李小红',
+                        age: 30,
+                        address: '上海市浦东新区世纪大道'
+                    },
+                    {
+                        name: '周小伟',
+                        age: 26,
+                        address: '深圳市南山区深南大道'
+                    }
+                ],
+                columns2: [
+                    {
+                        title: '姓名',
+                        key: 'name'
+                    },
+                    {
+                        title: '年龄',
+                        key: 'age'
+                    },
+                    {
+                        title: '地址',
+                        key: 'address'
+                    }
+                ],
+                data2: [
+                    {
+                        name: '王小明',
+                        age: 18,
+                        address: '北京市朝阳区芍药居'
+                    },
+                    {
+                        name: '张小刚',
+                        age: 25,
+                        address: '北京市海淀区西二旗'
+                    },
+                    {
+                        name: '李小红',
+                        age: 30,
+                        address: '上海市浦东新区世纪大道'
+                    },
+                    {
+                        name: '周小伟',
+                        age: 26,
+                        address: '深圳市南山区深南大道'
+                    },
+                    {
+                        name: '王小明',
+                        age: 18,
+                        address: '北京市朝阳区芍药居'
+                    },
+                    {
+                        name: '张小刚',
+                        age: 25,
+                        address: '北京市海淀区西二旗'
+                    },
+                    {
+                        name: '李小红',
+                        age: 30,
+                        address: '上海市浦东新区世纪大道'
+                    },
+                    {
+                        name: '周小伟',
+                        age: 26,
+                        address: '深圳市南山区深南大道'
+                    }
+                ],
+                columns3: [
+                    {
+                        title: '姓名',
+                        key: 'name',
+                        width: 100,
+                        fixed: 'left'
+                    },
+                    {
+                        title: '年龄',
+                        key: 'age',
+                        width: 100
+                    },
+                    {
+                        title: '省份',
+                        key: 'province',
+                        width: 100
+                    },
+                    {
+                        title: '市区',
+                        key: 'city',
+                        width: 100
+                    },
+                    {
+                        title: '地址',
+                        key: 'address',
+                        width: 200
+                    },
+                    {
+                        title: '邮编',
+                        key: 'zip',
+                        width: 100
+                    },
+                    {
+                        title: '操作',
+                        key: 'action',
+                        fixed: 'right',
+                        width: 120,
+                        render () {
+                            return `<i-button type="text" size="small">查看</i-button><i-button type="text" size="small">编辑</i-button>`;
+                        }
+                    }
+                ],
+                data3: [
+                    {
+                        name: '王小明',
+                        age: 18,
+                        address: '北京市朝阳区芍药居',
+                        province: '北京市',
+                        city: '朝阳区',
+                        zip: 100000
+                    },
+                    {
+                        name: '张小刚',
+                        age: 25,
+                        address: '北京市海淀区西二旗',
+                        province: '北京市',
+                        city: '海淀区',
+                        zip: 100000
+                    },
+                    {
+                        name: '李小红',
+                        age: 30,
+                        address: '上海市浦东新区世纪大道',
+                        province: '上海市',
+                        city: '浦东新区',
+                        zip: 100000
+                    },
+                    {
+                        name: '周小伟',
+                        age: 26,
+                        address: '深圳市南山区深南大道',
+                        province: '广东',
+                        city: '南山区',
+                        zip: 100000
+                    }
+                ],
+                data4: [
+                    {
+                        name: '王小明',
+                        age: 18,
+                        address: '北京市朝阳区芍药居',
+                        province: '北京市',
+                        city: '朝阳区',
+                        zip: 100000
+                    },
+                    {
+                        name: '张小刚',
+                        age: 25,
+                        address: '北京市海淀区西二旗',
+                        province: '北京市',
+                        city: '海淀区',
+                        zip: 100000
+                    },
+                    {
+                        name: '李小红',
+                        age: 30,
+                        address: '上海市浦东新区世纪大道',
+                        province: '上海市',
+                        city: '浦东新区',
+                        zip: 100000
+                    },
+                    {
+                        name: '周小伟',
+                        age: 26,
+                        address: '深圳市南山区深南大道',
+                        province: '广东',
+                        city: '南山区',
+                        zip: 100000
+                    },
+                    {
+                        name: '王小明',
+                        age: 18,
+                        address: '北京市朝阳区芍药居',
+                        province: '北京市',
+                        city: '朝阳区',
+                        zip: 100000
+                    },
+                    {
+                        name: '张小刚',
+                        age: 25,
+                        address: '北京市海淀区西二旗',
+                        province: '北京市',
+                        city: '海淀区',
+                        zip: 100000
+                    },
+                    {
+                        name: '李小红',
+                        age: 30,
+                        address: '上海市浦东新区世纪大道',
+                        province: '上海市',
+                        city: '浦东新区',
+                        zip: 100000
+                    },
+                    {
+                        name: '周小伟',
+                        age: 26,
+                        address: '深圳市南山区深南大道',
+                        province: '广东',
+                        city: '南山区',
+                        zip: 100000
+                    }
+                ]
             }
         },
         methods: {

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -152,6 +152,10 @@
             },
             noFilteredDataText: {
                 type: String
+            },
+            modal: {
+                type: Boolean,
+                default: false
             }
         },
         data () {
@@ -669,6 +673,15 @@
             window.removeEventListener('resize', this.handleResize, false);
         },
         watch: {
+            modal: {
+                handler (val) {
+                    if (val) {
+                        this.fixedHeader();
+                        this.handleResize();
+                    }
+                },
+                deep: true
+            },
             data: {
                 handler () {
                     this.objData = this.makeObjData();


### PR DESCRIPTION
使用过程中发现modal中嵌套table无法正确计算表格尺寸。
为table 增加了 `modal` 属性。
当 模态框显示时，正确计算表格尺寸；
```
modal: {
  handler (val) {
    if (val) {
      this.fixedHeader();
      this.handleResize();
    }
  },
  deep: true
}
```