### PR TITLE
修复菜单子组件为数组，name为数组索引active-name为0时不能选择

### DIFF
--- a/src/components/menu/menu.vue
+++ b/src/components/menu/menu.vue
@@ -24,7 +24,8 @@
                 default: 'light'
             },
             activeName: {
-                type: [String, Number]
+                type: [String, Number],
+                default:-1
             },
             openNames: {
                 type: Array,
@@ -69,9 +70,6 @@
         },
         methods: {
             updateActiveName () {
-                if (!this.currentActiveName) {
-                    this.currentActiveName = -1;
-                }
                 this.broadcast('Submenu', 'on-update-active-name', false);
                 this.broadcast('MenuItem', 'on-update-active-name', this.currentActiveName);
             },


### PR DESCRIPTION
以下使用场景时出现不能激活菜单的情况。
```
<Menu mode="horizontal" :active-name="0">
   <Menu-item :name="idx" v-for="(name,idx) in ['menu1','menu2']"></Menu-item>
</Menu>
```