### PR TITLE
[Fix] 使用 Breadcrumb 组件若初始化时没有设置子 Breadcrumb-item 则导航分隔符无法显示。

### DIFF
--- a/src/components/breadcrumb/breadcrumb.vue
+++ b/src/components/breadcrumb/breadcrumb.vue
@@ -22,6 +22,9 @@
         mounted () {
             this.updateChildren();
         },
+        updated () {
+        	this.updateChildren();
+        },
         methods: {
             updateChildren () {
                 this.$children.forEach((child) => {

--- a/src/components/breadcrumb/breadcrumb.vue
+++ b/src/components/breadcrumb/breadcrumb.vue
@@ -23,7 +23,7 @@
             this.updateChildren();
         },
         updated () {
-        	this.updateChildren();
+            this.updateChildren();
         },
         methods: {
             updateChildren () {


### PR DESCRIPTION
使用 Breadcrumb 组件，如果在组件 `mounted` 时没有为 Breadcrumb 设置有效的 Breadcrumb-item 子组件（比如 Breadcrumb-item 是通过 Ajax 或者本地缓存异步加载过来的），则 Breadcrumb 对子组件的 分隔符(seperator) 初始化会失败，因为此时获得的 `this.$children` 长度为0。

* 解决方案：

> 在父组件（Breadcrumb）的 updated 事件里加入更新子组建设置的逻辑。