### PR TITLE
poptip 确定默认宽度

### DIFF
--- a/src/components/poptip/poptip.vue
+++ b/src/components/poptip/poptip.vue
@@ -72,7 +72,8 @@
                 default: ''
             },
             width: {
-                type: [String, Number]
+                type: [String, Number],
+                default: 150
             },
             confirm: {
                 type: Boolean,


### PR DESCRIPTION
在文档中默认宽度是 150px，源码中却没有写清楚。在使用 Poptip 时，会遇到宽度不固定造成计算有误的问题，导致定位失败。