### PR TITLE
修正Modal的title属性不能初始化绑定默认值''的问题

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -55,7 +55,8 @@
                 default: true
             },
             title: {
-                type: String
+                type: [String, Boolean],
+                default: false
             },
             width: {
                 type: [Number, String],
@@ -217,7 +218,7 @@
 
             let showHead = true;
 
-            if (this.$slots.header === undefined && !this.title) {
+            if (this.$slots.header === undefined && this.title === false) {
                 showHead = false;
             }
 


### PR DESCRIPTION
#504 绑定Modal的title并初始化为''时会导致head消失
[http://jsbin.com/sohevo/edit?html,js,output](http://jsbin.com/sohevo/edit?html,js,output)