### PR TITLE
解决table在使用v-show时的尺寸自适应BUG

### DIFF
--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -99,7 +99,7 @@
                 this.currentVisible = false;
             },
             hasParent () {
-                const $parent = this.$parent.$parent;
+                const $parent = this.$parent && this.$parent.$parent && this.$parent.$parent.$parent;
                 if ($parent && $parent.$options.name === 'Dropdown') {
                     return $parent;
                 } else {

--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -108,6 +108,10 @@
             }
         },
         mounted () {
+            this.$on('on-click', (key) => {
+                const $parent = this.hasParent();
+                if ($parent) $parent.$emit('on-click', key);
+            });
             this.$on('on-hover-click', () => {
                 const $parent = this.hasParent();
                 if ($parent) {

--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -108,9 +108,6 @@
             }
         },
         mounted () {
-            this.$on('on-click', (key) => {
-                const $parent = this.hasParent();
-            });
             this.$on('on-hover-click', () => {
                 const $parent = this.hasParent();
                 if ($parent) {

--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -110,7 +110,6 @@
         mounted () {
             this.$on('on-click', (key) => {
                 const $parent = this.hasParent();
-                if ($parent) $parent.$emit('on-click', key);
             });
             this.$on('on-hover-click', () => {
                 const $parent = this.hasParent();

--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -99,7 +99,7 @@
                 this.currentVisible = false;
             },
             hasParent () {
-                const $parent = this.$parent.$parent.$parent;
+                const $parent = this.$parent.$parent;
                 if ($parent && $parent.$options.name === 'Dropdown') {
                     return $parent;
                 } else {

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -87,7 +87,7 @@
 <script>
     import tableHead from './table-head.vue';
     import tableBody from './table-body.vue';
-    import { oneOf, getStyle, deepCopy, getScrollBarSize } from '../../utils/assist';
+    import { oneOf, getStyle, getSize, deepCopy, getScrollBarSize } from '../../utils/assist';
     import Csv from '../../utils/csv';
     import ExportCsv from './export-csv';
     import Locale from '../../mixins/locale';
@@ -318,7 +318,7 @@
                     if (allWidth) {
                         this.tableWidth = this.columns.map(cell => cell.width).reduce((a, b) => a + b);
                     } else {
-                        this.tableWidth = parseInt(getStyle(this.$el, 'width')) - 1;
+                        this.tableWidth = parseInt(getSize(this.$el).width) - 1;
                     }
                     this.columnsWidth = {};
                     this.$nextTick(() => {
@@ -331,9 +331,9 @@
                             for (let i = 0; i < $td.length; i++) {    // can not use forEach in Firefox
                                 const column = this.cloneColumns[i];
 
-                                let width = parseInt(getStyle($td[i], 'width'));
+                                let width = parseInt(getSize($td[i]).width);
                                 if (i === autoWidthIndex) {
-                                    width = parseInt(getStyle($td[i], 'width')) - 1;
+                                    width = parseInt(getSize($td[i]).width) - 1;
                                 }
                                 if (column.width) width = column.width;
 
@@ -347,7 +347,7 @@
                         }
                     });
                     // get table real height,for fixed when set height prop,but height < table's height,show scrollBarWidth
-                    this.bodyRealHeight = parseInt(getStyle(this.$refs.tbody.$el, 'height'));
+                    this.bodyRealHeight = parseInt(getSize(this.$refs.tbody.$el).height);
                 });
             },
             handleMouseIn (_index) {
@@ -429,9 +429,9 @@
             fixedHeader () {
                 if (this.height) {
                     this.$nextTick(() => {
-                        const titleHeight = parseInt(getStyle(this.$refs.title, 'height')) || 0;
-                        const headerHeight = parseInt(getStyle(this.$refs.header, 'height')) || 0;
-                        const footerHeight = parseInt(getStyle(this.$refs.footer, 'height')) || 0;
+                        const titleHeight = parseInt(getSize(this.$refs.title).height) || 0;
+                        const headerHeight = parseInt(getSize(this.$refs.header).height) || 0;
+                        const footerHeight = parseInt(getSize(this.$refs.footer).height) || 0;
                         this.bodyHeight = this.height - titleHeight - headerHeight - footerHeight;
                     });
                 } else {

--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -63,7 +63,8 @@
                 barWidth: 0,
                 barOffset: 0,
                 activeKey: this.value,
-                showSlot: false
+                showSlot: false,
+                childCount: 0
             };
         },
         computed: {
@@ -233,6 +234,14 @@
         },
         mounted () {
             this.showSlot = this.$slots.extra !== undefined;
+            this.childCount = this.$children.length;
+        },
+        updated () {
+            if(this.childCount !== this.$children.length) {
+              this.childCount = this.$children.length;
+              //console.log('子控件发生数量变化');
+              this.updateNav();
         }
+      },
     };
 </script>

--- a/src/utils/assist.js
+++ b/src/utils/assist.js
@@ -76,6 +76,64 @@ export function getStyle (element, styleName) {
         return element.style[styleName];
     }
 }
+// getSize
+export function getSize(elem) {
+    let width = 0, height = 0;
+    const noneNodes = [], nodeStyle = [];
+    if (elem) {
+        getNoneNode(elem); //获取含有多层display:none的元素
+        setNodeStyle();
+        width = elem.clientWidth;
+        height = elem.clientHeight;
+        resumeNodeStyle();
+    }
+    return {
+        width : width,
+        height : height
+    };
+    function getNoneNode(node){
+        const display = getStyles(node).getPropertyValue('display');
+        const tagName = node.nodeName.toLowerCase();
+        if(display !== 'none' && tagName !== 'body'){
+            getNoneNode(node.parentNode);
+        } else {
+            noneNodes.push(node);
+            if(tagName !== 'body')
+                getNoneNode(node.parentNode);
+        }
+    }
+    //这方法才能获取最终是否有display属性设置，不能style.display。
+    function getStyles(elem) {
+        // Support: IE<=11+, Firefox<=30+ (#15098, #14150)
+        // IE throws on elements created in popups
+        // FF meanwhile throws on frame elements through "defaultView.getComputedStyle"
+        let view = elem.ownerDocument.defaultView;
+
+        if (!view || !view.opener) {
+            view = window;
+        }
+        return view.getComputedStyle(elem);
+    }
+    function setNodeStyle(){
+        for(let i = 0; i < noneNodes.length; i++){
+            const visibility = noneNodes[i].style.visibility;
+            const display = noneNodes[i].style.display;
+            const style = noneNodes[i].getAttribute("style");
+            //覆盖其他display样式
+            noneNodes[i].setAttribute("style", "visibility:hidden;display:block !important;" + style);
+            nodeStyle[i] = {
+                visibility :visibility,
+                display : display
+            }
+        }
+    }
+    function resumeNodeStyle(){
+        for(let i = 0; i < noneNodes.length; i++){
+            noneNodes[i].style.visibility = nodeStyle[i].visibility;
+            noneNodes[i].style.display = nodeStyle[i].display;
+        }
+    }
+}
 
 // firstUpperCase
 function firstUpperCase(str) {


### PR DESCRIPTION
解决table隐藏元素获取尺寸为0的BUG(比如在使用table组件时，通过v-show的方式加载组件，则header、footer等等尺寸获取均为0)。现已经修复，均可获取到正常尺寸。