### PR TITLE
修正table render的自定义组件中无法获取this.$store的问题

### DIFF
--- a/src/components/table/cell.vue
+++ b/src/components/table/cell.vue
@@ -96,6 +96,9 @@
                             },
                             components: components
                         });
+                        if ($parent.$store != undefined) {
+                            component.$store = $parent.$store;
+                        }
                         component.row = this.row;
                         component.column = this.column;
 


### PR DESCRIPTION
在table的render中生成的组件，组件内部的代码无法通过this.$store来获取vuex对象