### PR TITLE
[iView 2] input 支持 focus 方法

### DIFF
--- a/src/components/input/input.vue
+++ b/src/components/input/input.vue
@@ -7,6 +7,7 @@
                 <i class="ivu-icon ivu-icon-load-c ivu-load-loop" :class="[prefixCls + '-icon', prefixCls + '-icon-validate']" v-if="!icon"></i>
             </transition>
             <input
+                ref="input"
                 :type="type"
                 :class="inputClasses"
                 :placeholder="placeholder"
@@ -194,6 +195,13 @@
                 const maxRows = autosize.maxRows;
 
                 this.textareaStyles = calcTextareaHeight(this.$refs.textarea, minRows, maxRows);
+            },
+            focus() {
+                if (this.type === 'textarea') {
+                    this.$refs.textarea.focus();
+                } else {
+                    this.$refs.input.focus();
+                }
             }
         },
         watch: {


### PR DESCRIPTION
Input component support `focus()` method

我有个使用场景，需要能通过编程方式，让 `Input` 组件获得焦点，用户就可以避免操作鼠标点击，从而提高效率，所以加了这个方法。