### PR TITLE
解决 notice 英文标题被切掉下边的情况

### DIFF
--- a/src/styles/components/notice.less
+++ b/src/styles/components/notice.less
@@ -43,6 +43,7 @@
 
     &-title {
         font-size: @font-size-base;
+        line-height: 1.2em;
         color: @title-color;
         padding-right: 10px;
         overflow: hidden;


### PR DESCRIPTION
修改前:

<img width="513" alt="screen shot 2017-05-15 at 5 51 02 pm" src="https://cloud.githubusercontent.com/assets/1109648/26052151/170b4a52-3997-11e7-88f4-146adff33dbe.png">

修改后: 
<img width="519" alt="screen shot 2017-05-15 at 5 51 41 pm" src="https://cloud.githubusercontent.com/assets/1109648/26052176/2b4f36cc-3997-11e7-9928-7b2c1f6b8ffe.png">

