### PR TITLE
Fix table-cell render isssue.

### DIFF
--- a/src/components/table/cell.vue
+++ b/src/components/table/cell.vue
@@ -73,8 +73,6 @@
                     } else {
                         const $parent = this.context;
                         const template = this.column.render(this.row, this.column, this.index);
-                        const cell = document.createElement('div');
-                        cell.innerHTML = template;
 
                         this.$el.innerHTML = '';
                         let methods = {};
@@ -84,7 +82,7 @@
                                 methods[key] = func;
                             }
                         });
-                        const res = Vue.compile(cell.outerHTML);
+                        const res = Vue.compile(template);
                         // 获取父组件使用的局部 component
                         const components = {};
                         Object.getOwnPropertyNames($parent.$options.components).forEach(item => {


### PR DESCRIPTION
table cell 在使用render方法渲染时最好不要再套一层div上去，你让最外层已经加了text-overflow:eclipse的人怎么活？不应该改动原有的布局方式和样式。或者不这样直接的话加一个option可以去掉这层div也是可以的。