### PR TITLE
完善form-item label标签宽度在没有指定的情况下，自动计算，避免每一个label外部都要通过prop设置。

### DIFF
--- a/examples/routers/form.vue
+++ b/examples/routers/form.vue
@@ -1,5 +1,5 @@
 <template>
-    <div style="width: 300px;">
+    <div >
         <i-form ref="formValidate" :model="formValidate" :rules="ruleValidate" :label-width="80">
             <Form-item label="爱好" prop="interest">
                 <Checkbox-group v-model="formValidate.interest">
@@ -14,6 +14,41 @@
                 <i-button type="ghost" @click="handleReset('formValidate')" style="margin-left: 8px">重置</i-button>
             </Form-item>
         </i-form>
+        <i-form ref="formValidate" :model="formValidate" :rules="ruleValidate" inline>
+            <Form-item label="爱好" prop="interest">
+                <Checkbox-group v-model="formValidate.interest">
+                    <Checkbox label="吃饭"></Checkbox>
+                    <Checkbox label="睡觉"></Checkbox>
+                    <Checkbox label="跑步"></Checkbox>
+                    <Checkbox label="看电影"></Checkbox>
+                </Checkbox-group>
+            </Form-item>
+            <Form-item label="标题">
+                <Input v-model="formValidate.interest"></Input>
+            </Form-item>
+            <Form-item>
+                <i-button type="primary" @click="handleSubmit('formValidate')">提交</i-button>
+                <i-button type="ghost" @click="handleReset('formValidate')" style="margin-left: 8px">重置</i-button>
+            </Form-item>
+        </i-form>
+        <i-form ref="formValidate" :model="formValidate" :rules="ruleValidate" label-position="top">
+            <Form-item label="爱好" prop="interest">
+                <Checkbox-group v-model="formValidate.interest">
+                    <Checkbox label="吃饭"></Checkbox>
+                    <Checkbox label="睡觉"></Checkbox>
+                    <Checkbox label="跑步"></Checkbox>
+                    <Checkbox label="看电影"></Checkbox>
+                </Checkbox-group>
+            </Form-item>
+            <Form-item label="标题">
+                <Input v-model="formValidate.interest"></Input>
+            </Form-item>
+            <Form-item>
+                <i-button type="primary" @click="handleSubmit('formValidate')">提交</i-button>
+                <i-button type="ghost" @click="handleReset('formValidate')" style="margin-left: 8px">重置</i-button>
+            </Form-item>
+        </i-form>
+
     </div>
 </template>
 <script>

--- a/src/components/form/form-item.vue
+++ b/src/components/form/form-item.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="classes">
-        <label :class="[prefixCls + '-label']" :style="labelStyles" v-if="label"><slot name="label">{{ label }}</slot></label>
+        <label :class="[prefixCls + '-label']" :style="labelStyles" v-if="label" ref="formLabel"><slot name="label">{{ label }}</slot></label>
         <div :class="[prefixCls + '-content']" :style="contentStyles">
             <slot></slot>
             <transition name="fade">
@@ -11,7 +11,7 @@
 </template>
 <script>
     // https://github.com/ElemeFE/element/blob/dev/packages/form/src/form-item.vue
-
+	import { oneOf } from '../../utils/assist';
     import AsyncValidator from 'async-validator';
     import Emitter from '../../mixins/emitter';
 
@@ -79,7 +79,8 @@
                 validateState: '',
                 validateMessage: '',
                 validateDisabled: false,
-                validator: {}
+                validator: {},
+                autolabelWidth:null
             };
         },
         watch: {
@@ -133,7 +134,7 @@
             },
             contentStyles () {
                 let style = {};
-                const labelWidth = this.labelWidth || this.form.labelWidth;
+                const labelWidth = this.labelWidth || this.form.labelWidth || this.autolabelWidth;
                 if (labelWidth) {
                     style.marginLeft = `${labelWidth}px`;
                 }
@@ -219,6 +220,10 @@
             }
         },
         mounted () {
+			const labelWidth = this.labelWidth || this.form.labelWidth;
+			if(this.label && !labelWidth && oneOf(this.form.labelPosition, ['left', 'right'])){
+        		this.$nextTick(()=> {this.autolabelWidth = this.$refs['formLabel'].offsetWidth;});
+            }
             if (this.prop) {
                 this.dispatch('iForm', 'on-form-item-add', this);
 


### PR DESCRIPTION
完善form-item label标签宽度在没有指定的情况下，自动计算，避免每一个label外部都要通过prop设置。仅在label-position为left 和 right时使用