### PR TITLE
完善分页，添加loading 属性,如果页面正在加载，page里按钮应该不能点击

### DIFF
--- a/src/components/page/page.vue
+++ b/src/components/page/page.vue
@@ -125,7 +125,8 @@
             },
             styles: {
                 type: Object
-            }
+            },
+            loading: Boolean
         },
         data () {
             return {
@@ -206,6 +207,9 @@
         },
         methods: {
             changePage (page) {
+                if(this.loading){
+                    return;
+                }
                 if (this.currentPage != page) {
                     this.currentPage = page;
                     this.$emit('on-change', page);


### PR DESCRIPTION
完善分页，添加loading 属性,如果页面正在加载，page里按钮应该不能点击