### PR TITLE
impove table render logic,fix xss.

### DIFF
--- a/src/components/table/cell.vue
+++ b/src/components/table/cell.vue
@@ -4,7 +4,8 @@
         <template v-if="renderType === 'selection'">
             <Checkbox :value="checked" @on-change="toggleSelect" :disabled="disabled"></Checkbox>
         </template>
-        <template v-if="renderType === 'normal'"><span v-html="row[column.key]"></span></template>
+        <template v-if="renderType === 'html'"><span v-html="row[column.key]"></span></template>
+        <template v-if="renderType === 'normal'"><span>{{row[column.key]}}</span></template>
     </div>
 </template>
 <script>
@@ -120,6 +121,8 @@
                 this.renderType = 'index';
             } else if (this.column.type === 'selection') {
                 this.renderType = 'selection';
+            } else if (this.column.type === 'html') {
+                this.renderType = 'html';
             } else if (this.column.render) {
                 this.renderType = 'render';
             } else {

--- a/src/components/table/cell.vue
+++ b/src/components/table/cell.vue
@@ -4,7 +4,6 @@
         <template v-if="renderType === 'selection'">
             <Checkbox :value="checked" @on-change="toggleSelect" :disabled="disabled"></Checkbox>
         </template>
-
         <template v-if="renderType === 'html'"><span v-html="row[column.key]"></span></template>
         <template v-if="renderType === 'normal'"><span>{{row[column.key]}}</span></template>
         <template v-if="renderType === 'expand'">


### PR DESCRIPTION
table 组件在渲染 形如 "&#x3C;a href=&#x22;test-url&#x22;&#x3E;test&#x3C;/a&#x3E;" 的数据时，会被渲染成为html元素，容易造成xss( known as: cross site script 可 )漏洞,出于安全方面考虑,该行为不宜作为组件默认选项(默认安全原则),故将默认选项改为模板渲染，并引入 html 的渲染模式。

相关描述：
[1] https://en.wikipedia.org/wiki/Cross-site_scripting
[2] https://cn.vuejs.org/v2/api/#v-html