### PR TITLE
fix components/transfer name missing

### DIFF
--- a/src/components/transfer/transfer.vue
+++ b/src/components/transfer/transfer.vue
@@ -7,6 +7,7 @@
     const prefixCls = 'ivu-transfer';
 
     export default {
+        name: "Transfer",
         mixins: [ Emitter, Locale ],
         render (createElement) {
 


### PR DESCRIPTION
Transfer name missng, can cause the following problems:

![screenshot](http://freshin-static.oss-cn-hangzhou.aliyuncs.com/tmp/error.png)