### PR TITLE
优化table渲染，减少鼠标移动引起的重复渲染。

### DIFF
--- a/examples/routers/table.vue
+++ b/examples/routers/table.vue
@@ -11,9 +11,9 @@
                     {
                         type: 'expand',
                         render: (h) => {
-                            return h(etable);
-                        },
-                        width: 50
+                            console.log('expand called');
+                            return h('span', '扩展内容');
+                        }
                     },
                     {
                         title: '日期',

--- a/src/components/table/cell.vue
+++ b/src/components/table/cell.vue
@@ -136,10 +136,10 @@
 
             },
             toggleSelect () {
-                this.$parent.$parent.toggleSelect(this.index);
+                this.$parent.$parent.$parent.toggleSelect(this.index);
             },
             toggleExpand () {
-                this.$parent.$parent.toggleExpand(this.index);
+                this.$parent.$parent.$parent.toggleExpand(this.index);
             }
         },
         created () {

--- a/src/components/table/table-body.vue
+++ b/src/components/table/table-body.vue
@@ -5,27 +5,9 @@
         </colgroup>
         <tbody :class="[prefixCls + '-tbody']">
             <template v-for="(row, index) in data">
-                <tr
-                    :class="rowClasses(row._index)"
-                    @mouseenter.stop="handleMouseIn(row._index)"
-                    @mouseleave.stop="handleMouseOut(row._index)"
-                    @click.stop="clickCurrentRow(row._index)"
-                    @dblclick.stop="dblclickCurrentRow(row._index)">
-                    <td v-for="column in columns" :class="alignCls(column, row)">
-                        <Cell
-                            :fixed="fixed"
-                            :prefix-cls="prefixCls"
-                            :row="row"
-                            :key="row"
-                            :column="column"
-                            :natural-index="index"
-                            :index="row._index"
-                            :checked="rowChecked(row._index)"
-                            :disabled="rowDisabled(row._index)"
-                            :expanded="rowExpanded(row._index)"
-                        ></Cell>
-                    </td>
-                </tr>
+
+                <TableRow :prefix-cls="prefixCls" :index="index" :row="row" :columns="columns" :highlight-data="highlightData[index]"></TableRow>
+
                 <tr v-if="rowExpanded(row._index)">
                     <td :colspan="columns.length" :class="prefixCls + '-expanded-cell'">
                         <Expand :key="row" :row="row" :render="expandRender" :index="row._index"></Expand>
@@ -38,19 +20,21 @@
 <script>
     // todo :key="row"
     import Cell from './cell.vue';
+    import TableRow from './table-row.vue';
     import Expand from './expand.js';
     import Mixin from './mixin';
 
     export default {
         name: 'TableBody',
         mixins: [ Mixin ],
-        components: { Cell, Expand },
+        components: { Cell, TableRow, Expand },
         props: {
             prefixCls: String,
             styleObject: Object,
             columns: Array,
             data: Array,    // rebuildData
             objData: Object,
+            highlightData: Array,
             columnsWidth: Object,
             fixed: {
                 type: [Boolean, String],
@@ -72,16 +56,6 @@
             }
         },
         methods: {
-            rowClasses (_index) {
-                return [
-                    `${this.prefixCls}-row`,
-                    this.rowClsName(_index),
-                    {
-                        [`${this.prefixCls}-row-highlight`]: this.objData[_index] && this.objData[_index]._isHighlight,
-                        [`${this.prefixCls}-row-hover`]: this.objData[_index] && this.objData[_index]._isHover
-                    }
-                ];
-            },
             rowChecked (_index) {
                 return this.objData[_index] && this.objData[_index]._isChecked;
             },

--- a/src/components/table/table-row.vue
+++ b/src/components/table/table-row.vue
@@ -1,0 +1,81 @@
+<template>
+    <tr
+            :class="rowClasses(row._index)"
+            @mouseenter.stop="handleMouseIn(row._index)"
+            @mouseleave.stop="handleMouseOut(row._index)"
+            @click.stop="clickCurrentRow(row._index)"
+            @dblclick.stop="dblclickCurrentRow(row._index)">
+        <td v-for="column in columns" :class="alignCls(column, row)">
+            <Cell
+                    :fixed="fixed"
+                    :prefix-cls="prefixCls"
+                    :row="row"
+                    :key="row"
+                    :column="column"
+                    :natural-index="index"
+                    :index="row._index"
+                    :checked="rowChecked(row._index)"
+                    :disabled="rowDisabled(row._index)"
+                    :expanded="rowExpanded(row._index)"
+            ></Cell>
+        </td>
+    </tr>
+</template>
+<script>
+    // todo :key="row"
+    import Cell from './cell.vue';
+    import Mixin from './mixin';
+
+    export default {
+        name: 'TableRow',
+        mixins: [ Mixin ],
+        components: { Cell },
+        props: {
+            prefixCls: String,
+            columns: Array,
+            index: Number,
+            row: Object,
+            highlightData: Object,
+            fixed: {
+                type: [Boolean, String],
+                default: false
+            }
+        },
+        methods: {
+            rowClasses (_index) {
+                return [
+                    `${this.prefixCls}-row`,
+                    this.rowClsName(_index),
+                    {
+                        [`${this.prefixCls}-row-highlight`]: this.highlightData && this.highlightData._isHighlight,
+                        [`${this.prefixCls}-row-hover`]: this.highlightData && this.highlightData._isHover
+                    }
+                ];
+            },
+            rowChecked (_index) {
+                return this.$parent.rowChecked(_index);
+            },
+            rowDisabled(_index){
+                return this.$parent.rowDisabled(_index);
+            },
+            rowExpanded(_index){
+                return this.$parent.rowExpanded(_index);
+            },
+            rowClsName (_index) {
+                return this.$parent.rowClsName(_index);
+            },
+            handleMouseIn (_index) {
+                return this.$parent.handleMouseIn(_index);
+            },
+            handleMouseOut (_index) {
+                return this.$parent.handleMouseOut(_index);
+            },
+            clickCurrentRow (_index) {
+                this.$parent.clickCurrentRow(_index);
+            },
+            dblclickCurrentRow (_index) {
+                this.$parent.dblclickCurrentRow(_index);
+            }
+        }
+    };
+</script>

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -20,6 +20,7 @@
                     :columns="cloneColumns"
                     :data="rebuildData"
                     :columns-width="columnsWidth"
+                    :highlight-data="highlightData"
                     :obj-data="objData"></table-body>
             </div>
             <div
@@ -55,6 +56,7 @@
                         :columns="leftFixedColumns"
                         :data="rebuildData"
                         :columns-width="columnsWidth"
+                        :highlight-data="highlightData"
                         :obj-data="objData"></table-body>
                 </div>
             </div>
@@ -77,6 +79,7 @@
                         :columns="rightFixedColumns"
                         :data="rebuildData"
                         :columns-width="columnsWidth"
+                        :highlight-data="highlightData"
                         :obj-data="objData"></table-body>
                 </div>
             </div>
@@ -164,7 +167,8 @@
                 columnsWidth: {},
                 prefixCls: prefixCls,
                 compiledUids: [],
-                objData: this.makeObjData(),     // checkbox or highlight-row
+                objData: this.makeObjData(),     // checkbox
+                highlightData: this.makeHighlightData(), // for highlight-row
                 rebuildData: [],    // for sort or filter
                 cloneColumns: this.makeColumns(),
                 showSlotHeader: true,
@@ -355,24 +359,24 @@
             },
             handleMouseIn (_index) {
                 if (this.disabledHover) return;
-                if (this.objData[_index]._isHover) return;
-                this.objData[_index]._isHover = true;
+                if (this.highlightData[_index]._isHover) return;
+                this.highlightData[_index]._isHover = true;
             },
             handleMouseOut (_index) {
                 if (this.disabledHover) return;
-                this.objData[_index]._isHover = false;
+                this.highlightData[_index]._isHover = false;
             },
             highlightCurrentRow (_index) {
-                if (!this.highlightRow || this.objData[_index]._isHighlight) return;
+                if (!this.highlightRow || this.highlightData[_index]._isHighlight) return;
 
                 let oldIndex = -1;
-                for (let i in this.objData) {
-                    if (this.objData[i]._isHighlight) {
+                for (let i in this.highlightData) {
+                    if (this.highlightData[i]._isHighlight) {
                         oldIndex = parseInt(i);
-                        this.objData[i]._isHighlight = false;
+                        this.highlightData[i]._isHighlight = false;
                     }
                 }
-                this.objData[_index]._isHighlight = true;
+                this.highlightData[_index]._isHighlight = true;
                 const oldData = oldIndex < 0 ? null : JSON.parse(JSON.stringify(this.cloneData[oldIndex]));
                 this.$emit('on-current-change', JSON.parse(JSON.stringify(this.cloneData[_index])), oldData);
             },
@@ -428,7 +432,7 @@
                 //     }else{
                 //         this.objData[data._index]._isChecked = status;
                 //     }
-                    
+
                 // });
                 for(const data of this.rebuildData){
                     if(this.objData[data._index]._isDisabled){
@@ -597,7 +601,6 @@
                 let data = {};
                 this.data.forEach((row, index) => {
                     const newRow = deepCopy(row);// todo 直接替换
-                    newRow._isHover = false;
                     if (newRow._disabled) {
                         newRow._isDisabled = newRow._disabled;
                     } else {
@@ -613,14 +616,17 @@
                     } else {
                         newRow._isExpanded = false;
                     }
-                    if (newRow._highlight) {
-                        newRow._isHighlight = newRow._highlight;
-                    } else {
-                        newRow._isHighlight = false;
-                    }
                     data[index] = newRow;
                 });
                 return data;
+            },
+            makeHighlightData () {
+                return this.data.map(function () {
+                    return {
+                        _isHover: false,
+                        _isHighlight: false
+                    };
+                });
             },
             makeColumns () {
                 let columns = deepCopy(this.columns);
@@ -708,6 +714,7 @@
             data: {
                 handler () {
                     this.objData = this.makeObjData();
+                    this.highlightData = this.makeHighlightData();
                     this.rebuildData = this.makeDataWithSortAndFilter();
                     this.handleResize();
                     // here will trigger before clickCurrentRow, so use async


### PR DESCRIPTION
Vue 绑定的单个属性发生变化，会引起当前页面渲染， 故将 rowClasses 方法放到子组件中，鼠标移动时就不会引`table-body`的重新渲染。