### PR TITLE
fix: add keyup, keydown, keypress eventlistener of input component

### DIFF
--- a/src/components/input/input.vue
+++ b/src/components/input/input.vue
@@ -19,6 +19,9 @@
                 :number="number"
                 :autofocus="autofocus"
                 @keyup.enter="handleEnter"
+                @keyup="handleKeyup"
+                @keypress="handleKeypress"
+                @keydown="handleKeydown"
                 @focus="handleFocus"
                 @blur="handleBlur"
                 @input="handleInput"
@@ -39,6 +42,9 @@
             :value="value"
             :autofocus="autofocus"
             @keyup.enter="handleEnter"
+            @keyup="handleKeyup"
+            @keypress="handleKeypress"
+            @keydown="handleKeydown"
             @focus="handleFocus"
             @blur="handleBlur"
             @input="handleInput">
@@ -153,6 +159,15 @@
         methods: {
             handleEnter (event) {
                 this.$emit('on-enter', event);
+            },
+            handleKeydown (event) {
+                this.$emit('on-keydown', event);
+            },
+            handleKeypress(event) {
+                this.$emit('on-keypress', event);
+            },
+            handleKeyup (event) {
+                this.$emit('on-keyup', event);
             },
             handleIconClick (event) {
                 this.$emit('on-click', event);


### PR DESCRIPTION
Thanks for `iView` to build the project of our team.
But today, when I want to add keyup and keydown event listener of `Input` components, I failed.

It's the case of my project:

![](http://image.jiantuku.com/17-7-18/77395903.jpg?attname=file_1500378160192_d697.png&e=1500379210&token=el7kgPgYzpJoB23jrChWJ2gV3HpRl0VCzFn8rKKv:FswFsqfEQaGGYbIu9dDvn6SzaxI=)

I want to use keyup to set `shortcuts（快捷键）`  with Input components.I failed.

Now, I add the Event Listener to build my project, successfully.


Here is the test case, I was not commit it, but you can replace `examples/routers/input.vue` to see:
```vue
<template>
    <div style="width: 100px;">
        <Input v-model="value1" size="large" placeholder="large size" @on-enter="handleEnter" @on-keyup="handleKeyup" @on-keydown="handleKeydown" @on-keypress="handleKeypress"></Input>
        <br>
        <Input v-model="value2" placeholder="default size"></Input>
        <br>
        <Input v-model="value3" size="small" placeholder="small size"></Input>
        <br>
        <Input v-model="value1" size="large" placeholder="large size" icon="ios-clock-outline"></Input>
        <br>
        <Input v-model="value2" placeholder="default size" icon="ios-clock-outline"></Input>
        <br>
        <Input v-model="value3" size="small" placeholder="small size" icon="ios-clock-outline"></Input>
    </div>
</template>
<script>
    export default {
        data () {
            return {
                value1: '',
                value2: '',
                value3: ''
            }
        },
        methods: {
            handleKeydown() {
                console.log('keydown');
            },
            handleKeyup() {
                console.log('keyup');
            },
            handleEnter() {
                console.log('Keyup.Enter');
            },
            handleKeypress() {
                console.log('Keypress');
            }
        }
    }
</script>

```

Here is the result:

![](http://image.jiantuku.com/17-7-18/59237292.jpg?attname=file_1500378358252_563d.png&e=1500379210&token=el7kgPgYzpJoB23jrChWJ2gV3HpRl0VCzFn8rKKv:9ZkjO4wuKXvB6G_V-rVTZrf8p64=)
![](http://image.jiantuku.com/17-7-18/57056630.jpg?attname=file_1500378443798_17ce4.png&e=1500379210&token=el7kgPgYzpJoB23jrChWJ2gV3HpRl0VCzFn8rKKv:2uFEZulOPKB0WDZCOQYyh9UsqHY=)

En, `on-enter` and `on-keyup` is not contradictory.
