### PR TITLE
Fix a bug in tooltip when using always

### DIFF
--- a/src/components/base/popper.js
+++ b/src/components/base/popper.js
@@ -113,6 +113,9 @@ export default {
             popper._popper.style.transformOrigin = ['top', 'bottom'].indexOf(placement) > -1 ? `center ${ origin }` : `${ origin } center`;
         }
     },
+    mounted () {
+        this.updatePopper();        
+    },
     beforeDestroy() {
         if (isServer) return;
         if (this.popperJS) {


### PR DESCRIPTION
#1568 
call update() to updates the position of the 'always' tooltip in mounted()