### PR TITLE
responsive visibility directives across screen sizes

### DIFF
--- a/src/directives/responsive-visibility.js
+++ b/src/directives/responsive-visibility.js
@@ -1,0 +1,26 @@
+const addResponsiveVisibilityDirectives = (Vue) => {
+  Vue.directive('hidden-xs', {
+    inserted: (el) => {
+      el.className += ' hidden-xs';
+    }
+  });
+  Vue.directive('hidden-sm', {
+    inserted: (el) => {
+      el.className += ' hidden-sm';
+    }
+  });
+  Vue.directive('hidden-md', {
+    inserted: (el) => {
+      el.className += ' hidden-md';
+    }
+  });
+  Vue.directive('hidden-lg', {
+    inserted: (el) => {
+      el.className += ' hidden-lg';
+    }
+  });
+};
+
+export {
+  addResponsiveVisibilityDirectives
+};

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ import Upload from './components/upload';
 import { Row, Col } from './components/grid';
 import { Select, Option, OptionGroup } from './components/select';
 import locale from './locale';
+import { addResponsiveVisibilityDirectives } from './directives/responsive-visibility';
 
 const iview = {
     Affix,
@@ -132,6 +133,8 @@ const install = function (Vue, opts = {}) {
     Vue.prototype.$Message = Message;
     Vue.prototype.$Modal = Modal;
     Vue.prototype.$Notice = Notice;
+    
+    addResponsiveVisibilityDirectives(Vue);
 };
 
 // auto install

--- a/src/styles/common/index.less
+++ b/src/styles/common/index.less
@@ -2,3 +2,4 @@
 @import "iconfont/ionicons";
 @import "layout";
 @import "article";
+@import "responsive-visibility";

--- a/src/styles/common/responsive-visibility.less
+++ b/src/styles/common/responsive-visibility.less
@@ -1,0 +1,20 @@
+@media (max-width: @screen-xs-max) {
+  .hidden-xs {
+    display: none;
+  }
+}
+@media (min-width: @screen-sm-min) {
+  .hidden-sm {
+    display: none;
+  }
+}
+@media (min-width: @screen-md-min) {
+  .hidden-md {
+    display: none;
+  }
+}
+@media (min-width: @screen-lg-min) {
+  .hidden-lg {
+    display: none;
+  }
+}


### PR DESCRIPTION
Implements responsive classes for hiding elements across screen sizes, similar to bootstrap's `.hidden-xs` etc. classes

you can use them like this:

```html
<div v-hidden-xs>
   I'm hidden on xs        
</div>
<div v-hidden-lg>
   I'm hidden on lg
</div>
```