### PR TITLE
Broken initial scroll in time-picker with steps 

### DIFF
--- a/src/components/date-picker/base/time-spinner.vue
+++ b/src/components/date-picker/base/time-spinner.vue
@@ -171,7 +171,7 @@
                 const times = ['hours', 'minutes', 'seconds'];
                 this.$nextTick(() => {
                     times.forEach(type => {
-                        this.$refs[type].scrollTop = 24 * this.getScrollIndex(type, this[type]);
+                        this.$refs[type].scrollTop = 24 * this.getItemIndex(type, this[type]);
                     });
                 });
             },


### PR DESCRIPTION
**Problem:**
When opening a `time-picker` with `steps` and `value` the initial scroll is broken. This is basically something I forgot to check when I implemented the feature, so here is the fix :)

**Example** (broken): https://jsfiddle.net/r6w7s68p/2/
**Example** (fixed): https://jsfiddle.net/r6w7s68p/3/
