### PR TITLE
Use textContent to not escape html entities in Select options

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -291,7 +291,7 @@
                 this.findChild((child) => {
                     options.push({
                         value: child.value,
-                        label: (child.label === undefined) ? child.$el.innerHTML : child.label
+                        label: (child.label === undefined) ? child.$el.textContent : child.label
                     });
                     child.index = index++;
 

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -56,7 +56,7 @@ describe('Select.vue', () => {
       });
     });
 
-    xit('should accept normal characters', done => {
+    it('should accept normal characters', done => {
       vm = createVue({
         template: `
           <Select :value="2">


### PR DESCRIPTION
fixes #1687
fixes #622 
fixes #1112
fixes #1236
fixes #1211 
fixes #1765