### PR TITLE
fix SubMenu active bug

### DIFF
--- a/src/components/menu/submenu.vue
+++ b/src/components/menu/submenu.vue
@@ -54,7 +54,6 @@
                 return [
                     `${prefixCls}-submenu`,
                     {
-                        [`${prefixCls}-item-active`]: this.active,
                         [`${prefixCls}-opened`]: this.opened,
                         [`${prefixCls}-submenu-disabled`]: this.disabled
                     }


### PR DESCRIPTION
给 SubMenu 组件添加 active 属性会导致在三级菜单中的 SubMenu 文字高亮一直存在不消失

![pic](http://c.shoyuf.top/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202017-08-30%20%E4%B8%8B%E5%8D%886.21.04.png)