### PR TITLE
Make date more IE friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "async-validator": "^1.7.1",
-    "core-js": "^2.4.1",
+    "core-js": "^2.5.0",
     "deepmerge": "^1.5.0",
     "popper.js": "^0.6.4",
     "tinycolor2": "^1.4.1"

--- a/src/components/date-picker/util.js
+++ b/src/components/date-picker/util.js
@@ -1,9 +1,17 @@
 import dateUtil from '../../utils/date';
 
 export const toDate = function(date) {
-    date = new Date(date);
-    if (isNaN(date.getTime())) return null;
-    return date;
+    let _date = new Date(date);
+    // IE patch start (#1422)
+    if (isNaN(_date.getTime()) && typeof date === 'string'){
+        _date = date.split('-').map(Number);
+        _date[1] += 1;
+        _date = new Date(..._date);
+    }
+    // IE patch end
+
+    if (isNaN(_date.getTime())) return null;
+    return _date;
 };
 
 export const formatDate = function(date, format) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 // es6 polyfill
+import 'core-js/fn/array/find';
 import 'core-js/fn/array/find-index';
 
 import Affix from './components/affix';


### PR DESCRIPTION
**Problem:** IE 11 cannot parse date strings where month or date is only one character. 

This PR calls the date constructor with the separated string parts, only in case they fail to parse as dates.

Added also `Array.prototype.find` because [IE11 does not have it](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Browser_compatibility).

fixes #1422