### PR TITLE
修正Table组件显示间隔斑马纹时，高亮标记点击行

### DIFF
--- a/src/styles/components/table.less
+++ b/src/styles/components/table.less
@@ -191,7 +191,7 @@
 
     tr&-row-hover{
         td{
-            background-color: @table-td-hover-bg;
+            background-color: @table-td-hover-bg !important;
         }
     }
 


### PR DESCRIPTION
修正Table组件显示间隔斑马纹时，高亮标记点击行。
之前斑马纹行背景色样式优先级较高，高亮行背景色被覆盖掉。现在给高亮行背景色加上 !important。