### PR TITLE
修复table里嵌套table报 Cannot read property 'width' of undefined"的错误

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -351,7 +351,7 @@
                         if (allWidth) autoWidthIndex = this.cloneColumns.findIndex(cell => !cell.width);//todo 这行可能有问题
 
                         if (this.data.length) {
-                            const $td = this.$refs.tbody.$el.querySelectorAll('tbody tr')[0].childNodes;
+                            const $td = this.$refs.tbody.$el.querySelectorAll('tbody tr')[0].children;
                             for (let i = 0; i < $td.length; i++) {    // can not use forEach in Firefox
                                 const column = this.cloneColumns[i];
 

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -351,7 +351,7 @@
                         if (allWidth) autoWidthIndex = this.cloneColumns.findIndex(cell => !cell.width);//todo 这行可能有问题
 
                         if (this.data.length) {
-                            const $td = this.$refs.tbody.$el.querySelectorAll('tbody tr')[0].querySelectorAll('td');
+                            const $td = this.$refs.tbody.$el.querySelectorAll('tbody tr')[0].childNodes;
                             for (let i = 0; i < $td.length; i++) {    // can not use forEach in Firefox
                                 const column = this.cloneColumns[i];
 


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

table里的td再创建个table会报以下错误，已测试过
>[Vue warn]: Error in nextTick: "TypeError: Cannot read property 'width' of undefined"