### PR TITLE
force string dates parse

### DIFF
--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -514,6 +514,8 @@
                     } else if (val && type === 'timerange' && Array.isArray(val) && val.length === 2 && !(val[0] instanceof Date) && !(val[1] instanceof Date)) {
                         val = val.join(RANGE_SEPARATOR);
                         val = parser(val, this.format || DEFAULT_FORMATS[type]);
+                    } else if (typeof val === 'string' && type.indexOf('time') !== 0 ){
+                        val = parser(val, this.format || DEFAULT_FORMATS[type]);
                     }
 
                     this.internalValue = val;


### PR DESCRIPTION
When we compile code with Nuxt `Date` objects gets converted to `.ISOString()`. So if we have a example with `year: new Date('1977')` server side, this gets converted to `year: '1976-12-31T23:00:00.000Z'` in client side, and breaks validation ([jsFiddle](https://jsfiddle.net/Sergio_fiddle/grbzcx80/)).

If we force a date re-check the Date will be parsed as Object by DatePicker and thus pass validating.

fixes https://github.com/iview/iview/issues/1971
