### PR TITLE
Return empty string if the date input doesn't parse

### DIFF
--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -366,6 +366,8 @@
                         } else {
                             correctValue = formatDate(parsedDate, format);
                         }
+                    } else if (!parsedDate) {
+                        correctValue = '';
                     } else {
                         correctValue = oldValue;
                     }


### PR DESCRIPTION
When we insert invalid input in date-picker `Input` iview `throw` error. This change makes the input value be empty.

fixes #1872, fixes #1995
