### PR TITLE
Remove unused and typo cursor style in ColorPicker

### DIFF
--- a/src/styles/components/color-picker.less
+++ b/src/styles/components/color-picker.less
@@ -106,7 +106,6 @@
             position: absolute;
         }
         &-circle{
-            cursor: head;
             width: 4px;
             height: 4px;
             box-shadow: 0 0 0 1.5px #fff, inset 0 0 1px 1px rgba(0,0,0,.3), 0 0 1px 2px rgba(0,0,0,.4);


### PR DESCRIPTION
It seems `cursor:hand` only worked in IE 5.5 and below.
In this place, the cursor style has already defined by its parent div, so remove it.