### PR TITLE
checkbox组件支持排序

### DIFF
--- a/examples/routers/checkbox.vue
+++ b/examples/routers/checkbox.vue
@@ -26,6 +26,28 @@
             <Checkbox v-for="item in tags" :label="item.label" :key="item.label" true-value="true"></Checkbox>
         </Checkbox-group>
         <div>{{ fruit }}</div>
+        
+        <section>
+            <strong>无排序案例(随意勾选下列多选框)</strong>
+            <div>
+                题目：下列哪些是属于前框框架和库（）<br/>
+                答案选项：<Input style="width: 360px;"  v-model="exam" readonly></Input>
+            </div>
+            <Checkbox-group v-model="value" size="large" @on-change="checkExam">
+                <Checkbox v-for="item in examList" :label="item.label" :key="item.label" true-value="true">{{item.text}}</Checkbox>
+            </Checkbox-group>
+        </section>
+
+        <section>
+            <strong>有排序案例(随意勾选下列多选框)</strong>
+            <div>
+                题目：下列哪些是属于前框框架和库（）<br/>
+                答案选项：<Input style="width: 360px;"  v-model="exam2" readonly></Input>
+            </div>
+            <Checkbox-group v-model="value2" size="large" @on-change="checkExam2" sort>
+                <Checkbox v-for="item in examList" :label="item.label" :key="item.label" true-value="true">{{item.text}}</Checkbox>
+            </Checkbox-group>
+        </section>
     </div>
 </template>
 <script>
@@ -36,7 +58,12 @@
                 fruit: ['苹果'],
                 tags: [],
                 testValue1: null,
-                testValue2: null
+                testValue2: null,
+                examList: [],
+                exam: "",
+                value: [],
+                exam2: "",
+                value2: []
             }
         },
         mounted () {
@@ -53,6 +80,41 @@
                     }
                 ]
             }, 1000);
+            this.getExamList();
+        },
+        methods: {
+            getExamList () {
+                this.examList = [
+                    {
+                        label: 'A',
+                        text: 'A.Vue'
+                    },
+                    {
+                        label: 'B',
+                        text: 'B.React'
+                    },
+                    {
+                        label: 'C',
+                        text: 'C.Angular'
+                    },
+                    {
+                        label: 'D',
+                        text: 'D.jQuery'
+                    }
+                ];
+            },
+            checkExam (data) {
+                this.exam = "";
+                data.forEach(item => {
+                    this.exam = this.exam +" "+ item;
+                })
+            },
+            checkExam2 (data) {
+                this.exam2 = "";
+                data.forEach(item => {
+                    this.exam2 = this.exam2 +" "+ item;
+                })
+            }
         }
     }
 </script>

--- a/examples/routers/checkbox.vue
+++ b/examples/routers/checkbox.vue
@@ -22,7 +22,7 @@
             <Checkbox :true-value="0" :false-value="1" v-model="testValue2">test number</Checkbox>
             {{ testValue2 }}
         </div>
-        <Checkbox-group v-model="fruit" size="large">
+        <Checkbox-group v-model="fruit" size="large" sort>
             <Checkbox v-for="item in tags" :label="item.label" :key="item.label" true-value="true"></Checkbox>
         </Checkbox-group>
         <div>{{ fruit }}</div>

--- a/src/components/checkbox/checkbox-group.vue
+++ b/src/components/checkbox/checkbox-group.vue
@@ -22,6 +22,10 @@
                 validator (value) {
                     return oneOf(value, ['small', 'large', 'default']);
                 }
+            },
+            sort: {
+                type: Boolean,
+                default: false
             }
         },
         data () {

--- a/src/components/checkbox/checkbox.vue
+++ b/src/components/checkbox/checkbox.vue
@@ -121,6 +121,9 @@
                 this.$emit('input', value);
 
                 if (this.group) {
+                    if(this.parent.sort){
+                        this.sortModel();
+                    }
                     this.parent.change(this.model);
                 } else {
                     this.$emit('on-change', value);
@@ -129,6 +132,22 @@
             },
             updateModel () {
                 this.currentValue = this.value === this.trueValue;
+            },
+            sortModel () {
+                let preIndex, current, model = this.model, labelArray = [];
+                this.parent.$children.forEach(child => {
+                    labelArray.push(child.label);
+                })
+                for(var i=1; i<model.length; i++){
+                    preIndex = i -1;
+                    current = model[i];
+                    while(preIndex>=0 && labelArray.indexOf(model[preIndex]) > labelArray.indexOf(current)){
+                        model[preIndex+1] = model[preIndex];
+                        preIndex--;
+                    }
+                    model[preIndex+1] = current;
+                }
+                this.model = model;
             }
         },
         watch: {


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

添加checkbox组件支持按顺序返回value值。
目前的checkbox组件在CheckboxGroup组合下，得到勾选的值是按照勾选时的顺序排列的，比如有A，B，C，D几个多选框，可能勾选的顺序是B->A->C->D，返回的value值就是["B","D","C","A"]，但是在一些应用场景下需要得到的是按照多选框的顺序来排列的value值，比如考试系统的题目选项等。
