### PR TITLE
修正`FormItem`使用`:error`动态设置错误信息后，`validateState`的值`error`永远无法清空的BUG

### DIFF
--- a/src/components/form/form-item.vue
+++ b/src/components/form/form-item.vue
@@ -85,8 +85,13 @@
         },
         watch: {
             error (val) {
-                this.validateMessage = val;
-                this.validateState = 'error';
+                if (val === '') {
+                    this.validateMessage = '';
+                    this.validateState = '';
+                } else {
+                    this.validateMessage = val;
+                    this.validateState = 'error';
+                }
             },
             validateStatus (val) {
                 this.validateState = val;


### PR DESCRIPTION
为`FormItem`设置`:error`，以动态将其标记为验证错误；但是此后，即使内容修改为正确的值，再次执行验证时，`FormItem`的边框仍然是红色的，因为`validateState`的值还是`error`


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
