### PR TITLE
修复select选项在带滚动条的Modal里错位的bug

### DIFF
--- a/src/components/select/dropdown.vue
+++ b/src/components/select/dropdown.vue
@@ -74,7 +74,18 @@
             }
         },
         created () {
-            this.$on('on-update-popper', this.update);
+            var parent = this.$parent
+            var isInModal = false
+            while (parent && parent.$vnode && !isInModal) {
+                if (parent.$vnode.componentOptions.tag === 'Modal') {
+                    isInModal = true
+                } else {
+                    parent = parent.$parent
+                }
+            }
+            if (!isInModal) {
+                this.$on('on-update-popper', this.update);
+            }
             this.$on('on-destroy-popper', this.destroy);
         },
         beforeDestroy () {


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

目前遇到这样的问题，在带滚动条的Modal里有Select会出现Options错位的bug，如下图（该图我已在自己的代码上修复了）

<img src="http://www.chjtx.com/assets/images/iview2-select-drag-bug.jpg">

我看到有这样的样式：
```css
.ivu-modal .ivu-select-dropdown {
    position: absolute!important;
}
```

我猜作者的原意是select在modal里不使用fixed也不随父元素滚动而自动定位，但只在css做了处理，没在js做处理，所以我加了这段js