### PR TITLE
Refactor tree

### DIFF
--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -44,13 +44,13 @@
         data () {
             return {
                 prefixCls: prefixCls,
-                stateTree: JSON.parse(JSON.stringify(this.data)),
+                stateTree: this.data,
                 flatState: [],
             };
         },
         watch: {
             data(){
-                this.stateTree = JSON.parse(JSON.stringify(this.data));
+                this.stateTree = this.data;
                 this.flatState = this.compileFlatState();
                 this.rebuildTree();
             }
@@ -109,7 +109,7 @@
                     this.updateTreeDown(node, {checked: true});
                     // propagate upwards
                     const parentKey = this.flatState[node.nodeKey].parent;
-                    if (!parentKey) return;
+                    if (!parentKey && parentKey !== 0) return;
                     const parent = this.flatState[parentKey].node;
                     const childHasCheckSetter = typeof node.checked != 'undefined' && node.checked;
                     if (childHasCheckSetter && parent.checked != node.checked) {

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -1,25 +1,22 @@
 <template>
     <div :class="prefixCls">
         <Tree-node
-            v-for="item in data"
+            v-for="item in stateTree"
             :key="item.nodeKey"
             :data="item"
             visible
             :multiple="multiple"
             :show-checkbox="showCheckbox">
         </Tree-node>
-        <div :class="[prefixCls + '-empty']" v-if="!data.length">{{ localeEmptyText }}</div>
+        <div :class="[prefixCls + '-empty']" v-if="!stateTree.length">{{ localeEmptyText }}</div>
     </div>
 </template>
 <script>
     import TreeNode from './node.vue';
-    import { findComponentsDownward } from '../../utils/assist';
     import Emitter from '../../mixins/emitter';
     import Locale from '../../mixins/locale';
 
     const prefixCls = 'ivu-tree';
-
-    let key = 1;
 
     export default {
         name: 'Tree',
@@ -46,92 +43,128 @@
         },
         data () {
             return {
-                prefixCls: prefixCls
+                prefixCls: prefixCls,
+                stateTree: JSON.parse(JSON.stringify(this.data)),
+                flatState: [],
             };
+        },
+        watch: {
+            data(){
+                this.stateTree = JSON.parse(JSON.stringify(this.data));
+                this.flatState = this.compileFlatState();
+                this.rebuildTree();
+            }
         },
         computed: {
             localeEmptyText () {
-                if (this.emptyText === undefined) {
+                if (typeof this.emptyText === 'undefined') {
                     return this.t('i.tree.emptyText');
                 } else {
                     return this.emptyText;
                 }
-            }
+            },
         },
         methods: {
+            compileFlatState () { // so we have always a relation parent/children of each node
+                let keyCounter = 0;
+                const flatTree = [];
+                function flattenChildren(node, parent) {
+                    node.nodeKey = keyCounter++;
+                    flatTree[node.nodeKey] = { node: node, nodeKey: node.nodeKey };
+                    if (typeof parent != 'undefined') {
+                        flatTree[node.nodeKey].parent = parent.nodeKey;
+                        flatTree[parent.nodeKey].children.push(node.nodeKey);
+                    }
+
+                    if (node.children) {
+                        flatTree[node.nodeKey].children = [];
+                        node.children.forEach(child => flattenChildren(child, node));
+                    }
+                }
+                this.stateTree.forEach(rootNode => {
+                    flattenChildren(rootNode);
+                });
+                return flatTree;
+            },
+            updateTreeUp(nodeKey){
+                const parentKey = this.flatState[nodeKey].parent;
+                if (typeof parentKey == 'undefined') return;
+
+                const node = this.flatState[nodeKey].node;
+                const parent = this.flatState[parentKey].node;
+                if (node.checked == parent.checked && node.indeterminate == parent.indeterminate) return; // no need to update upwards
+
+                if (node.checked == true) {
+                    this.$set(parent, 'checked', parent.children.every(node => node.checked));
+                    this.$set(parent, 'indeterminate', !parent.checked);
+                } else {
+                    this.$set(parent, 'checked', false);
+                    this.$set(parent, 'indeterminate', parent.children.some(node => node.checked || node.indeterminate));
+                }
+                this.updateTreeUp(parentKey);
+            },
+            rebuildTree () { // only called when `data` prop changes
+                const checkedNodes = this.getCheckedNodes();
+                checkedNodes.forEach(node => {
+                    this.updateTreeDown(node, {checked: true});
+                    // propagate upwards
+                    const parentKey = this.flatState[node.nodeKey].parent;
+                    if (!parentKey) return;
+                    const parent = this.flatState[parentKey].node;
+                    const childHasCheckSetter = typeof node.checked != 'undefined' && node.checked;
+                    if (childHasCheckSetter && parent.checked != node.checked) {
+                        this.updateTreeUp(node.nodeKey); // update tree upwards
+                    }
+                });
+            },
+
             getSelectedNodes () {
-                const nodes = findComponentsDownward(this, 'TreeNode');
-                return nodes.filter(node => node.data.selected).map(node => node.data);
+                /* public API */
+                return this.flatState.filter(obj => obj.node.selected).map(obj => obj.node);
             },
             getCheckedNodes () {
-                const nodes = findComponentsDownward(this, 'TreeNode');
-                return nodes.filter(node => node.data.checked).map(node => node.data);
+                /* public API */
+                return this.flatState.filter(obj => obj.node.checked).map(obj => obj.node);
             },
-            updateData (isInit = true) {
-                // init checked status
-                function reverseChecked(data) {
-                    if (!data.nodeKey) data.nodeKey = key++;
-                    if (data.children && data.children.length) {
-                        let checkedLength = 0;
-                        data.children.forEach(node => {
-                            if (node.children) node = reverseChecked(node);
-                            if (node.checked) checkedLength++;
-                        });
-                        if (isInit) {
-                            if (checkedLength >= data.children.length) data.checked = true;
-                        } else {
-                            data.checked = checkedLength >= data.children.length;
-                        }
-                        return data;
-                    } else {
-                        return data;
-                    }
+            updateTreeDown(node, changes = {}) {
+                for (let key in changes) {
+                    this.$set(node, key, changes[key]);
                 }
-                
-                function forwardChecked(data) {
-                    if (data.children) {
-                        data.children.forEach(node => {
-                            if (data.checked) node.checked = true;
-                            if (node.children) node = forwardChecked(node);
-                        });
-                        return data;
-                    } else {
-                        return data;
-                    }
+                if (node.children) {
+                    node.children.forEach(child => {
+                        this.updateTreeDown(child, changes);
+                    });
                 }
-                this.data.map(node => reverseChecked(node)).map(node => forwardChecked(node));
-                this.broadcast('TreeNode', 'indeterminate');
+            },
+            handleSelect (nodeKey) {
+                const node = this.flatState[nodeKey].node;
+                if (!this.multiple){ // reset selected
+                    const currentSelectedKey = this.flatState.findIndex(obj => obj.node.selected);
+                    if (currentSelectedKey >= 0) this.$set(this.flatState[currentSelectedKey].node, 'selected', false);
+                }
+                this.$set(node, 'selected', !node.selected);
+
+                this.$emit('on-select-change', this.getSelectedNodes());
+            },
+            handleCheck({ checked, nodeKey }) {
+                const node = this.flatState[nodeKey].node;
+                this.$set(node, 'checked', checked);
+                this.$set(node, 'indeterminate', false);
+
+                this.updateTreeUp(nodeKey); // propagate up
+                this.updateTreeDown(node, {checked, indeterminate: false}); // reset `indeterminate` when going down
+
+                this.$emit('on-check-change', this.getCheckedNodes());
             }
+        },
+        created(){
+            this.flatState = this.compileFlatState();
+            this.rebuildTree();
         },
         mounted () {
-            this.updateData();
-            this.$on('selected', ori => {
-                const nodes = findComponentsDownward(this, 'TreeNode');
-                nodes.forEach(node => {
-                    this.$set(node.data, 'selected', false);
-                });
-                this.$set(ori, 'selected', true);
-            });
-            this.$on('on-selected', () => {
-                this.$emit('on-select-change', this.getSelectedNodes());
-            });
-            this.$on('checked', () => {
-                this.updateData(false);
-            });
-            this.$on('on-checked', () => {
-                this.$emit('on-check-change', this.getCheckedNodes());
-            });
-            this.$on('toggle-expand', (payload) => {
-                this.$emit('on-toggle-expand', payload);
-            });
-        },
-        watch: {
-            data () {
-                this.$nextTick(() => {
-                    this.updateData();
-                    this.broadcast('TreeNode', 'indeterminate');
-                });
-            }
+            this.$on('on-check', this.handleCheck);
+            this.$on('on-selected', this.handleSelect);
+            this.$on('toggle-expand', node => this.$emit('on-toggle-expand', node));
         }
     };
 </script>

--- a/src/styles/components/tree.less
+++ b/src/styles/components/tree.less
@@ -38,7 +38,10 @@
     }
     &-arrow{
         cursor: pointer;
-        i{
+        width: 12px;
+        text-align: center;
+        display: inline-block;
+        i {
             transition: all @transition-time @ease-in-out;
         }
         &-open{


### PR DESCRIPTION

Refactor Tree component code to fix async loading and bugs.

I removed the findComponentDownwards logic so we can do `v-if` and not render parts of Tree that are not expanded. This way we have a state tree complete even if some nodes are not rendered in DOM.

fixes #1993
fixes #1943
fixes #1897
fixes #1776
fixes #791 
fixes #1717
fixes #1693 
fixes #1597

closes #1767

related #587 (with this PR the `indeterminate` state is part of the Tree `data`, but we have no event for `indeterminate`. Not sure it is needed)
