### PR TITLE
add distance-to-edge property

### DIFF
--- a/src/components/scroll/scroll.vue
+++ b/src/components/scroll/scroll.vue
@@ -128,7 +128,6 @@
             },
 
             onCallback(dir) {
-                console.log('onCallback', dir);
                 this.isLoading = true;
                 this.showBodyLoader = true;
                 if (dir > 0) {


### PR DESCRIPTION


This ads a new prop in Scroll where callback can be fired by distance to edge. If distance passed is negative, it will fire before reaching edge.

Possible values:
(as discussed in #2137)

 - **Number**: in this case will use **same value** to both `top` and `bottom` values
 - **Array**: in this case will be used as `[top value, bottom value`

fixes #2137 