### PR TITLE
export locale objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,8 @@ import Tree from './components/tree';
 import Upload from './components/upload';
 import {Row, Col} from './components/grid';
 import {Select, Option, OptionGroup} from './components/select';
-import locale from './locale';
+import locale from './locale/index';
+import locales from './locale/locales';
 
 const iview = {
     Affix,
@@ -149,4 +150,4 @@ if (typeof window !== 'undefined' && window.Vue) {
     install(window.Vue);
 }
 
-module.exports = Object.assign(iview, {install}); // eslint-disable-line no-undef
+module.exports = Object.assign(iview, {install, locales}); // eslint-disable-line no-undef

--- a/src/locale/locales.js
+++ b/src/locale/locales.js
@@ -1,0 +1,35 @@
+// export all locale files
+
+import deDE from './lang/de-DE.js';
+import enUS from './lang/en-US.js';
+import esES from './lang/es-ES.js';
+import frFR from './lang/fr-FR.js';
+import idID from './lang/id-ID.js';
+import jaJP from './lang/ja-JP.js';
+import koKR from './lang/ko-KR.js';
+import ptBR from './lang/pt-BR.js';
+import ptPT from './lang/pt-PT.js';
+import ruRU from './lang/ru-RU.js';
+import svSE from './lang/sv-SE.js';
+import trTR from './lang/tr-TR.js';
+import viVN from './lang/vi-VN.js';
+import zhCN from './lang/zh-CN.js';
+import zhTW from './lang/zh-TW.js';
+
+export default {
+    'de-DE': deDE,
+    'en-US': enUS,
+    'es-ES': esES,
+    'fr-FR': frFR,
+    'id-ID': idID,
+    'ja-JP': jaJP,
+    'ko-KR': koKR,
+    'pt-BR': ptBR,
+    'pt-PT': ptPT,
+    'ru-RU': ruRU,
+    'sv-SE': svSE,
+    'tr-TR': trTR,
+    'vi-VN': viVN,
+    'zh-CN': zhCN,
+    'zh-TW': zhTW
+};


### PR DESCRIPTION
Export `locale` objects so we can use iView directly on the browser easier.

This changes allows to use locale on the browser directly:

```
const lang = 'sv-SE';
const locale = iview.locales[lang];
Vue.use(iview, {
    locale: locale
});
```

Example: http://jsfiddle.net/Sergio_fiddle/174cbLax/
Related to Stackoverflow question: https://stackoverflow.com/q/46989680/2256325

