### PR TITLE
normalize autocomplete and spellcheck

### DIFF
--- a/src/components/form/form.vue
+++ b/src/components/form/form.vue
@@ -1,5 +1,5 @@
 <template>
-    <form :class="classes"><slot></slot></form>
+    <form :class="classes" :autocomplete="autocomplete"><slot></slot></form>
 </template>
 <script>
     // https://github.com/ElemeFE/element/blob/dev/packages/form/src/form.vue
@@ -32,6 +32,12 @@
             showMessage: {
                 type: Boolean,
                 default: true
+            },
+            autocomplete: {
+                validator (value) {
+                    return oneOf(value, ['on', 'off']);
+                },
+                default: 'off'
             }
         },
         data () {
@@ -67,14 +73,14 @@
                             }
                             if (++count === this.fields.length) {
                                 // all finish
-                                resolve(valid)
+                                resolve(valid);
                                 if (typeof callback === 'function') {
                                     callback(valid);
                                 }
                             }
                         });
                     });
-                })
+                });
             },
             validateField(prop, cb) {
                 const field = this.fields.filter(field => field.prop === prop)[0];

--- a/src/components/input-number/input-number.vue
+++ b/src/components/input-number/input-number.vue
@@ -20,6 +20,7 @@
                 :class="inputClasses"
                 :disabled="disabled"
                 autocomplete="off"
+                spellcheck="false"
                 :autofocus="autofocus"
                 @focus="focus"
                 @blur="blur"

--- a/src/components/input/input.vue
+++ b/src/components/input/input.vue
@@ -9,6 +9,7 @@
             <input
                 :id="elementId"
                 :autocomplete="autocomplete"
+                :spellcheck="spellcheck"
                 ref="input"
                 :type="type"
                 :class="inputClasses"
@@ -34,6 +35,7 @@
             v-else
             :id="elementId"
             :autocomplete="autocomplete"
+            :spellcheck="spellcheck"
             ref="textarea"
             :class="textareaClasses"
             :style="textareaStyles"
@@ -113,6 +115,10 @@
                 default: false
             },
             autofocus: {
+                type: Boolean,
+                default: false
+            },
+            spellcheck: {
                 type: Boolean,
                 default: false
             },

--- a/src/components/page/options.vue
+++ b/src/components/page/options.vue
@@ -7,7 +7,13 @@
         </div>
         <div v-if="showElevator" :class="ElevatorClasses">
             {{ t('i.page.goto') }}
-            <input type="text" :value="_current" @keyup.enter="changePage">
+            <input
+              type="text"
+              :value="_current"
+              autocomplete="off"
+              spellcheck="false"
+              @keyup.enter="changePage"
+            >
             {{ t('i.page.p') }}
         </div>
     </div>

--- a/src/components/page/page.vue
+++ b/src/components/page/page.vue
@@ -10,6 +10,8 @@
             <input
                 type="text"
                 :value="currentPage"
+                autocomplete="off"
+                spellcheck="false"
                 @keydown="keyDown"
                 @keyup="keyUp"
                 @change="keyUp">

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -21,6 +21,8 @@
                     :class="[prefixCls + '-input']"
                     :placeholder="showPlaceholder ? localePlaceholder : ''"
                     :style="inputStyle"
+                    autocomplete="off"
+                    spellcheck="false"
                     @blur="handleBlur"
                     @keydown="resetInputState"
                     @keydown.delete="handleInputDelete"


### PR DESCRIPTION
This allows the user to control the `autocomplete` and `spellcheck` attribute in `<Input>` and `<Form>` component. 

This PR also forces `off` in input elements that are not part of forms, and are used internally by iview.

Related: https://github.com/iview/iview/issues/2118
