### PR TITLE
Don't use includes to make IE happy and avoid Polyfill

### DIFF
--- a/src/components/date-picker/util.js
+++ b/src/components/date-picker/util.js
@@ -113,7 +113,7 @@ export const formatDateLabels = (function() {
             });
             return {
                 label: label,
-                type: component.includes('yy') ? 'year' : 'month'
+                type: component.indexOf('yy') != -1 ? 'year' : 'month'
             };
         });
         return {


### PR DESCRIPTION
Avoid using `.includes()` to make IE happy and avoid adding Polyfill

fixes #2330 