### PR TITLE
add possibility to load locale files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ import Upload from './components/upload';
 import {Row, Col} from './components/grid';
 import {Select, Option, OptionGroup} from './components/select';
 import locale from './locale/index';
+import lang from './locale/lang';
 
 const iview = {
     Affix,
@@ -153,6 +154,10 @@ module.exports = {  // eslint-disable-line no-undef
     version: '2.6.0',
     locale: locale.use,
     i18n: locale.i18n,
+    get currentLanguage(){
+        return locale.currentLanguage;
+    },
+    lang,
     install,
     Affix,
     Alert,
@@ -219,12 +224,6 @@ module.exports = {  // eslint-disable-line no-undef
     Transfer,
     Tree,
     Upload
-};
-
-module.exports.lang = (code) => { // eslint-disable-line no-undef
-    const langObject = window['iview/locale'].default;
-    if (code === langObject.i.locale) locale.use(langObject);
-    else console.log(`The ${code} language pack is not loaded.`); // eslint-disable-line no-console
 };
 
 module.exports.default = module.exports;   // eslint-disable-line no-undef

--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -45,4 +45,8 @@ export const i18n = function(fn) {
     i18nHandler = fn || i18nHandler;
 };
 
-export default { use, t, i18n };
+const locale = { use, t, i18n, get currentLanguage(){
+    return lang;
+} };
+
+export default locale;

--- a/src/locale/lang.js
+++ b/src/locale/lang.js
@@ -1,0 +1,56 @@
+// i18n async loader
+import locale from './index';
+
+const defaultLang = locale.currentLanguage;
+const locales = {
+    [defaultLang.i.locale]: defaultLang
+    // more will be added
+};
+
+function loadPackage(lang, ref) {
+    if (typeof ref == 'string') {
+        // load remote
+        return new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.onerror = reject;
+            script.onload = function() {
+                locales[lang] = window['iview/locale'].default;
+                resolve();
+            };
+            script.src = ref;
+            document.querySelector('head').appendChild(script);
+        });
+    } else if (ref.i.locale == lang) {
+        // load object directly
+        locales[lang] = ref;
+        return Promise.resolve(); // load object directly
+    }
+}
+
+function queueHandler(arr) {
+    return new Promise((resolve, reject) => {
+        const next = arr.shift();
+        if (!next) return resolve();
+
+        return loadPackage(next.lang, next.ref).then(() => resolve(queueHandler(arr))).catch(reject);
+    });
+}
+
+function applyLanguage(langCode) {
+    const langObject = locales[langCode] || (window['iview/locale'] && window['iview/locale'].default);
+    if (langCode && langCode === langObject.i.locale) locale.use(langObject);
+    else console.log(`The ${langCode} language pack is not loaded.`); // eslint-disable-line no-console
+}
+
+export default (langCode, languages = {}) => {
+
+    const queue = Object.keys(languages).reduce((arr, lang) => {
+        return arr.concat({ lang: lang, ref: languages[lang] });
+    }, []);
+
+	// apply langCode and return available locales
+    return queueHandler(queue).then(() => {
+        applyLanguage(langCode);
+        return locales;
+    });
+};


### PR DESCRIPTION
I open the PR so we can discuss code/API features around this.

This PR makes possible to change locale in client side. 
It makes possible to load external files, or load directly objects.

Example would be:

```
const languages = {
    'en-US': './dist/locale/en-US.js',
    'sv-SE': './dist/locale/sv-SE.js'
};
iview.lang('en-US', languages).then(locales => {
    this.languages = locales; // locales is a Object with all loaded locales
    this.currentLang = iview.currentLanguage.i.locale; // currentLanguage is the current active language
});
```

Its also possible to use only `iview.lang('en-US')` to change to a pre-loaded language, or do:

`iview.lang('en-US', {i: { ... etc, a whole lang object ... }})`



