### PR TITLE
menu中异步增加子组件，状态不同步

### DIFF
--- a/src/components/menu/menu.vue
+++ b/src/components/menu/menu.vue
@@ -97,9 +97,11 @@
                 }
             }
         },
-        mounted () {
+        updated () {
             this.updateActiveName();
             this.updateOpened();
+        },
+        mounted () {
             this.$on('on-menu-item-select', (name) => {
                 this.currentActiveName = name;
                 this.$emit('on-select', name);


### PR DESCRIPTION
menu组件在mounted时执行updateActiveName，导致当在menu组件中异步增加menu-item时，新增的menu-item组件无法得到当前activeName，无法高亮。