### PR TITLE
Fix datepicker i18n

### DIFF
--- a/src/components/date-picker/base/date-table.vue
+++ b/src/components/date-picker/base/date-table.vue
@@ -30,7 +30,7 @@
             year: {},
             month: {},
             selectionMode: {
-                default: 'day'
+                default: 'date'
             },
             disabledDate: {},
             minDate: {},

--- a/src/components/date-picker/panel/date-range.vue
+++ b/src/components/date-picker/panel/date-range.vue
@@ -111,6 +111,7 @@
                 <time-picker
                     ref="timePicker"
                     v-show="isTime"
+                    :format="format"
                     @on-pick="handleTimePick"
                     @on-pick-click="handlePickClick"></time-picker>
             </div>
@@ -132,6 +133,8 @@
     import MonthTable from '../base/month-table.vue';
     import TimePicker from './time-range.vue';
     import Confirm from '../base/confirm.vue';
+
+    import { oneOf } from '../../../utils/assist';
     import { toDate, prevMonth, nextMonth, initTimeDate, formatDateLabels } from '../util';
     import datePanelLabel from './date-panel-label.vue';
 
@@ -142,32 +145,58 @@
     const datePrefixCls = 'ivu-date-picker';
 
     export default {
-        name: 'DatePicker',
+        name: 'RangeDatePickerPanel',
         mixins: [ Mixin, Locale ],
         components: { Icon, DateTable, YearTable, MonthTable, TimePicker, Confirm, datePanelLabel },
+        props: {
+            confirm: {
+                type: Boolean,
+                default: false
+            },
+            showTime: {
+                type: Boolean,
+                default: false
+            },
+            format: {
+                type: String,
+                default: 'yyyy-MM-dd'
+            },
+            value: {
+                type: Array,
+            },
+            selectionMode: {
+                type: String,
+                validator (value) {
+                    return oneOf(value, ['year', 'month', 'date', 'range']);
+                },
+                default: 'range'
+            },
+            shortcuts: {
+                type: Array,
+                default: () => []
+            },
+            disabledDate: {
+                type: Function,
+                default: () => false
+            }
+        },
         data () {
+            const date = initTimeDate();
             return {
                 prefixCls: prefixCls,
                 datePrefixCls: datePrefixCls,
-                shortcuts: [],
-                date: initTimeDate(),
-                value: '',
+                date: date,
                 minDate: '',
                 maxDate: '',
-                confirm: false,
                 rangeState: {
                     endDate: null,
                     selecting: false
                 },
-                showTime: false,
-                disabledDate: '',
                 leftCurrentView: 'date',
                 rightCurrentView: 'date',
-                selectionMode: 'range',
-                leftTableYear: null,
-                rightTableYear: null,
-                isTime: false,
-                format: 'yyyy-MM-dd'
+                leftTableYear: date.getFullYear(),
+                rightTableYear: date.getFullYear(),
+                isTime: false
             };
         },
         computed: {
@@ -248,9 +277,6 @@
             },
             maxDate (val) {
                 if (this.showTime) this.$refs.timePicker.dateEnd = val;
-            },
-            format (val) {
-                if (this.showTime) this.$refs.timePicker.format = val;
             },
             isTime (val) {
                 if (val) this.$refs.timePicker.updateScroll();
@@ -406,7 +432,6 @@
                 this.$refs.timePicker.date = this.minDate;
                 this.$refs.timePicker.dateEnd = this.maxDate;
                 this.$refs.timePicker.value = this.value;
-                this.$refs.timePicker.format = this.format;
                 this.$refs.timePicker.showDate = true;
             }
         }

--- a/src/components/date-picker/panel/date-range.vue
+++ b/src/components/date-picker/panel/date-range.vue
@@ -163,6 +163,7 @@
             },
             value: {
                 type: Array,
+                default: () => [initTimeDate(), initTimeDate()]
             },
             selectionMode: {
                 type: String,
@@ -181,7 +182,7 @@
             }
         },
         data () {
-            const date = initTimeDate();
+            const date = this.value[0];
             return {
                 prefixCls: prefixCls,
                 datePrefixCls: datePrefixCls,

--- a/src/components/date-picker/panel/date.vue
+++ b/src/components/date-picker/panel/date.vue
@@ -59,6 +59,7 @@
                 <time-picker
                     ref="timePicker"
                     show-date
+                    :format="format"
                     v-show="currentView === 'time'"
                     @on-pick="handleTimePick"
                     @on-pick-click="handlePickClick"></time-picker>
@@ -85,31 +86,55 @@
     import Mixin from './mixin';
     import Locale from '../../../mixins/locale';
 
+    import { oneOf } from '../../../utils/assist';
     import { initTimeDate, siblingMonth, formatDateLabels } from '../util';
 
     const prefixCls = 'ivu-picker-panel';
     const datePrefixCls = 'ivu-date-picker';
 
     export default {
-        name: 'DatePicker',
+        name: 'DatePickerPanel',
         mixins: [ Mixin, Locale ],
         components: { Icon, DateTable, YearTable, MonthTable, TimePicker, Confirm, datePanelLabel },
+        props: {
+            confirm: {
+                type: Boolean,
+                default: false
+            },
+            showTime: {
+                type: Boolean,
+                default: false
+            },
+            format: {
+                type: String,
+                default: 'yyyy-MM-dd'
+            },
+            value: {},
+            selectionMode: {
+                type: String,
+                validator (value) {
+                    return oneOf(value, ['year', 'month', 'date']);
+                },
+                default: 'date'
+            },
+            shortcuts: {
+                type: Array,
+                default: () => []
+            },
+            disabledDate: {
+                type: Function,
+                default: () => false
+            }
+        },
         data () {
             return {
                 prefixCls: prefixCls,
                 datePrefixCls: datePrefixCls,
-                shortcuts: [],
-                currentView: 'date',
+                currentView: this.selectionMode || 'date',
                 date: initTimeDate(),
-                value: '',
-                showTime: false,
-                selectionMode: 'day',
-                disabledDate: '',
                 year: null,
                 month: null,
-                confirm: false,
-                isTime: false,
-                format: 'yyyy-MM-dd'
+                isTime: false
             };
         },
         computed: {
@@ -151,8 +176,8 @@
             date (val) {
                 if (this.showTime) this.$refs.timePicker.date = val;
             },
-            format (val) {
-                if (this.showTime) this.$refs.timePicker.format = val;
+            selectionMode(){
+                this.currentView = this.selectionMode;
             },
             currentView (val) {
                 if (val === 'time') this.$refs.timePicker.updateScroll();
@@ -232,7 +257,7 @@
                 }
             },
             handleDatePick (value) {
-                if (this.selectionMode === 'day') {
+                if (this.selectionMode === 'date') {
                     this.$emit('on-pick', new Date(value.getTime()));
                     this.date = new Date(value);
                 }
@@ -253,7 +278,6 @@
                 // todo 这里可能有问题，并不能进入到这里，但不影响正常使用
                 this.$refs.timePicker.date = this.date;
                 this.$refs.timePicker.value = this.value;
-                this.$refs.timePicker.format = this.format;
                 this.$refs.timePicker.showDate = true;
             }
         }

--- a/src/components/date-picker/panel/date.vue
+++ b/src/components/date-picker/panel/date.vue
@@ -109,7 +109,10 @@
                 type: String,
                 default: 'yyyy-MM-dd'
             },
-            value: {},
+            value: {
+                type: Date,
+                default: () => initTimeDate()
+            },
             selectionMode: {
                 type: String,
                 validator (value) {
@@ -131,7 +134,7 @@
                 prefixCls: prefixCls,
                 datePrefixCls: datePrefixCls,
                 currentView: this.selectionMode || 'date',
-                date: initTimeDate(),
+                date: this.value,
                 year: null,
                 month: null,
                 isTime: false

--- a/src/components/date-picker/panel/time-range.vue
+++ b/src/components/date-picker/panel/time-range.vue
@@ -59,20 +59,23 @@
     const timePrefixCls = 'ivu-time-picker';
 
     export default {
-        name: 'TimePicker',
+        name: 'RangeTimePickerPanel',
         mixins: [ Mixin, Locale ],
         components: { TimeSpinner, Confirm },
         props: {
             steps: {
                 type: Array,
                 default: () => []
+            },
+            format: {
+                type: String,
+                default: 'HH:mm:ss'
             }
         },
         data () {
             return {
                 prefixCls: prefixCls,
                 timePrefixCls: timePrefixCls,
-                format: 'HH:mm:ss',
                 showDate: false,
                 date: initTimeDate(),
                 dateEnd: initTimeDate(),

--- a/src/components/date-picker/panel/time.vue
+++ b/src/components/date-picker/panel/time.vue
@@ -37,13 +37,17 @@
     const timePrefixCls = 'ivu-time-picker';
 
     export default {
-        name: 'TimePicker',
+        name: 'TimePickerPanel',
         mixins: [ Mixin, Locale ],
         components: { TimeSpinner, Confirm },
         props: {
             steps: {
                 type: Array,
                 default: () => []
+            },
+            format: {
+                type: String,
+                default: 'HH:mm:ss'
             }
         },
         data () {
@@ -53,7 +57,6 @@
                 date: initTimeDate(),
                 value: '',
                 showDate: false,
-                format: 'HH:mm:ss',
                 hours: '',
                 minutes: '',
                 seconds: '',

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -473,6 +473,10 @@
                 return newDate;
             },
             onPick(date, visible = false) {
+
+                // create new Date objects so Vue's reactive trigger gets called
+                date = Array.isArray(date) ? date.map(d => new Date(d)) : new Date(date);
+
                 if (!this.isConfirm) this.visible = visible;
                 this.currentValue = date;
                 this.picker.value = date;

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -29,12 +29,33 @@
                 ref="drop"
                 :data-transfer="transfer"
                 v-transfer-dom>
-                <div ref="picker"></div>
+                <div>
+                    <component
+                        :is="panel"
+                        :visible="visible"
+                        :showTime="type === 'datetime' || type === 'datetimerange'"
+                        :confirm="isConfirm"
+                        :selectionMode="selectionMode"
+                        :steps="steps"
+                        :format="format"
+                        v-bind="picker"
+                        :disabledHours="disabledHours"
+                        :disabledMinutes="disabledMinutes"
+                        :disabledSeconds="disabledSeconds"
+                        :hideDisabledOptions="hideDisabledOptions"
+                        @on-pick="onPick"
+                        @on-pick-clear="handleClear"
+                        @on-pick-success="onPickSuccess"
+                        @on-pick-click="disableClickOutSide = true"
+                    ></component>
+                </div>
             </Drop>
         </transition>
     </div>
 </template>
 <script>
+
+
     import iInput from '../../components/input/input.vue';
     import Drop from '../../components/select/dropdown.vue';
     import clickoutside from '../../directives/clickoutside';
@@ -206,14 +227,26 @@
             },
             elementId: {
                 type: String
+            },
+            steps: {
+                type: Array,
+                default: () => []
             }
         },
         data () {
+            const isTimePicker = this.type.indexOf('time') === 0;
+            const timePickerProps = isTimePicker ? {} : {
+                disabledHours: [],
+                disabledMinutes: [],
+                disabledSeconds: [],
+                hideDisabledOptions: false
+            };
             return {
+                ...timePickerProps,
                 prefixCls: prefixCls,
                 showClose: false,
                 visible: false,
-                picker: null,
+                picker: {showTime: true, ...this.options},
                 internalValue: '',
                 disableClickOutSide: false,    // fixed when click a date,trigger clickoutside to close picker
                 disableCloseUnderTransfer: false,  // transfer 模式下，点击Drop也会触发关闭
@@ -244,7 +277,7 @@
                     return 'year';
                 }
 
-                return 'day';
+                return 'date';
             },
             visualValue: {
                 get () {
@@ -274,6 +307,9 @@
                     }
                     if (this.picker) this.picker.value = value;
                 }
+            },
+            isConfirm(){
+                return this.confirm || this.type === 'datetime' || this.type === 'datetimerange';
             }
         },
         methods: {
@@ -400,58 +436,13 @@
             },
             handleClear () {
                 this.visible = false;
-                this.internalValue = '';
-                this.currentValue = '';
+                this.internalValue = this.type.includes('range') ? [null, null] : '';
+                this.currentValue = this.type.includes('range') ? [null, null] : '';
                 this.$emit('on-clear');
                 this.dispatch('FormItem', 'on-form-change', '');
-                // #2215，当初始设置了 value，直接点 clear，这时 this.picker 还没有加载
-                if (!this.picker) {
-                    this.emitChange('');
-                }
+                this.emitChange('');
             },
             showPicker () {
-                if (!this.picker) {
-                    let isConfirm = this.confirm;
-                    const type = this.type;
-
-                    this.picker = this.Panel.$mount(this.$refs.picker);
-                    if (type === 'datetime' || type === 'datetimerange') {
-                        isConfirm = true;
-                        this.picker.showTime = true;
-                    }
-                    this.picker.value = this.internalValue;
-                    this.picker.confirm = isConfirm;
-                    this.picker.selectionMode = this.selectionMode;
-                    if (this.format) this.picker.format = this.format;
-
-                    // TimePicker
-                    if (this.disabledHours) this.picker.disabledHours = this.disabledHours;
-                    if (this.disabledMinutes) this.picker.disabledMinutes = this.disabledMinutes;
-                    if (this.disabledSeconds) this.picker.disabledSeconds = this.disabledSeconds;
-                    if (this.hideDisabledOptions) this.picker.hideDisabledOptions = this.hideDisabledOptions;
-
-                    const options = this.options;
-                    for (const option in options) {
-                        this.picker[option] = options[option];
-                    }
-
-                    this.picker.$on('on-pick', (date, visible = false) => {
-                        if (!isConfirm) this.visible = visible;
-                        this.currentValue = date;
-                        this.picker.value = date;
-                        this.picker.resetView && this.picker.resetView();
-                        this.emitChange(date);
-                    });
-
-                    this.picker.$on('on-pick-clear', () => {
-                        this.handleClear();
-                    });
-                    this.picker.$on('on-pick-success', () => {
-                        this.visible = false;
-                        this.$emit('on-ok');
-                    });
-                    this.picker.$on('on-pick-click', () => this.disableClickOutSide = true);
-                }
                 if (this.internalValue instanceof Date) {
                     this.picker.date = new Date(this.internalValue.getTime());
                 } else {
@@ -480,7 +471,19 @@
                     newDate = [newDate.split(RANGE_SEPARATOR)[0], newDate.split(RANGE_SEPARATOR)[1]];
                 }
                 return newDate;
+            },
+            onPick(date, visible = false) {
+                if (!this.isConfirm) this.visible = visible;
+                this.currentValue = date;
+                this.picker.value = date;
+                this.picker.resetView && this.picker.resetView();
+                this.emitChange(date);
+            },
+            onPickSuccess(){
+                this.visible = false;
+                this.$emit('on-ok');
             }
+
         },
         watch: {
             visible (val) {
@@ -537,13 +540,9 @@
                 }
             }
         },
-        beforeDestroy () {
-            if (this.picker) {
-                this.picker.$destroy();
-            }
-        },
         mounted () {
             if (this.open !== null) this.visible = this.open;
+            window.picker = this;
         }
     };
 </script>

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -38,6 +38,7 @@
                         :selectionMode="selectionMode"
                         :steps="steps"
                         :format="format"
+                        :value="pickerDate"
                         v-bind="picker"
                         :disabledHours="disabledHours"
                         :disabledMinutes="disabledMinutes"
@@ -61,7 +62,7 @@
     import clickoutside from '../../directives/clickoutside';
     import TransferDom from '../../directives/transfer-dom';
     import { oneOf } from '../../utils/assist';
-    import { formatDate, parseDate } from './util';
+    import { formatDate, parseDate, initTimeDate } from './util';
     import Emitter from '../../mixins/emitter';
 
     const prefixCls = 'ivu-date-picker';
@@ -291,7 +292,6 @@
 
                     return formatter(value, this.format || format);
                 },
-
                 set (value) {
                     if (value) {
                         const type = this.type;
@@ -307,6 +307,16 @@
                     }
                     if (this.picker) this.picker.value = value;
                 }
+            },
+            pickerDate(){
+                const isRange = this.type.includes('range');
+                if (isRange){
+                    const isArray = Array.isArray(this.internalValue);
+                    return (isArray ? this.internalValue : [this.internalValue]).map(date => date || initTimeDate());
+                } else {
+                    return this.internalValue || initTimeDate();
+                }
+
             },
             isConfirm(){
                 return this.confirm || this.type === 'datetime' || this.type === 'datetimerange';
@@ -444,7 +454,7 @@
             },
             showPicker () {
                 if (this.internalValue instanceof Date) {
-                    this.picker.date = new Date(this.internalValue.getTime());
+                    this.picker.date = new Date(this.internalValue);
                 } else {
                     this.picker.value = this.internalValue;
                 }
@@ -507,6 +517,8 @@
             internalValue(val) {
                 if (!val && this.picker && typeof this.picker.handleClear === 'function') {
                     this.picker.handleClear();
+                } else if (val && typeof val.getTime === 'function'){
+                    this.picker.date = this.internalValue;
                 }
 //                this.$emit('input', val);
             },

--- a/src/components/date-picker/picker/date-picker.js
+++ b/src/components/date-picker/picker/date-picker.js
@@ -1,14 +1,6 @@
-import Vue from 'vue';
 import Picker from '../picker.vue';
-import DatePanel from '../panel/date.vue';
-import DateRangePanel from '../panel/date-range.vue';
-
-const getPanel = function (type) {
-    if (type === 'daterange' || type === 'datetimerange') {
-        return DateRangePanel;
-    }
-    return DatePanel;
-};
+import DatePickerPanel from '../panel/date.vue';
+import RangeDatePickerPanel from '../panel/date-range.vue';
 
 import { oneOf } from '../../../utils/assist';
 
@@ -23,15 +15,11 @@ export default {
         },
         value: {}
     },
-    watch: {
-        type(value){
-            const typeMap = {
-                year: 'year',
-                month: 'month',
-                date: 'day'
-            };
-            const validType = oneOf(value, Object.keys(typeMap));
-            if (validType) this.Panel.selectionMode = typeMap[value];
+    components: { DatePickerPanel, RangeDatePickerPanel },
+    computed: {
+        panel(){
+            const isRange =  this.type === 'daterange' || this.type === 'datetimerange';
+            return isRange ? 'RangeDatePickerPanel' : 'DatePickerPanel';
         }
     },
     created () {
@@ -42,8 +30,5 @@ export default {
                 this.currentValue = '';
             }
         }
-
-        const panel = getPanel(this.type);
-        this.Panel = new Vue(panel);
     }
 };

--- a/src/components/date-picker/picker/time-picker.js
+++ b/src/components/date-picker/picker/time-picker.js
@@ -1,20 +1,13 @@
-import Vue from 'vue';
 import Picker from '../picker.vue';
-import TimePanel from '../panel/time.vue';
-import TimeRangePanel from '../panel/time-range.vue';
+import TimePickerPanel from '../panel/time.vue';
+import RangeTimePickerPanel from '../panel/time-range.vue';
 import Options from '../time-mixins';
-
-const getPanel = function (type) {
-    if (type === 'timerange') {
-        return TimeRangePanel;
-    }
-    return TimePanel;
-};
 
 import { oneOf } from '../../../utils/assist';
 
 export default {
     mixins: [Picker, Options],
+    components: { TimePickerPanel, RangeTimePickerPanel },
     props: {
         type: {
             validator (value) {
@@ -22,11 +15,13 @@ export default {
             },
             default: 'time'
         },
-        steps: {
-            type: Array,
-            default: () => []
-        },
         value: {}
+    },
+    computed: {
+        panel(){
+            const isRange =  this.type === 'timerange';
+            return isRange ? 'RangeTimePickerPanel' : 'TimePickerPanel';
+        }
     },
     created () {
         if (!this.currentValue) {
@@ -36,11 +31,5 @@ export default {
                 this.currentValue = '';
             }
         }
-        const Panel = Vue.extend(getPanel(this.type));
-        this.Panel = new Panel({
-            propsData: {
-                steps: this.steps
-            }
-        });
     }
 };

--- a/src/locale/format.js
+++ b/src/locale/format.js
@@ -6,45 +6,40 @@
 
 const RE_NARGS = /(%|)\{([0-9a-zA-Z_]+)\}/g;
 
-export default function() {
-    // const { hasOwn } = Vue.util;
-    function hasOwn (obj, key) {
-        return Object.prototype.hasOwnProperty.call(obj, key);
+function hasOwn (obj, key) {
+    return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/**
+ * template
+ *
+ * @param {String} string
+ * @param {Array} ...args
+ * @return {String}
+ */
+
+export default function template(string, ...args) {
+    if (args.length === 1 && typeof args[0] === 'object') {
+        args = args[0];
     }
 
-    /**
-     * template
-     *
-     * @param {String} string
-     * @param {Array} ...args
-     * @return {String}
-     */
+    if (!args || !args.hasOwnProperty) {
+        args = {};
+    }
 
-    function template(string, ...args) {
-        if (args.length === 1 && typeof args[0] === 'object') {
-            args = args[0];
-        }
+    return string.replace(RE_NARGS, (match, prefix, i, index) => {
+        let result;
 
-        if (!args || !args.hasOwnProperty) {
-            args = {};
-        }
-
-        return string.replace(RE_NARGS, (match, prefix, i, index) => {
-            let result;
-
-            if (string[index - 1] === '{' &&
-                string[index + match.length] === '}') {
-                return i;
-            } else {
-                result = hasOwn(args, i) ? args[i] : null;
-                if (result === null || result === undefined) {
-                    return '';
-                }
-
-                return result;
+        if (string[index - 1] === '{' &&
+            string[index + match.length] === '}') {
+            return i;
+        } else {
+            result = hasOwn(args, i) ? args[i] : null;
+            if (result === null || result === undefined) {
+                return '';
             }
-        });
-    }
 
-    return template;
+            return result;
+        }
+    });
 }

--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -1,21 +1,10 @@
 import defaultLang from './lang/zh-CN';
-import Vue from 'vue';
-import deepmerge from 'deepmerge';
-import Format from './format';
+import format from './format';
 
-const format = Format(Vue);
 let lang = defaultLang;
-let merged = false;
 let i18nHandler = function() {
-    const vuei18n = Object.getPrototypeOf(this || Vue).$t;
-    if (typeof vuei18n === 'function' && !!Vue.locale) {
-        if (!merged) {
-            merged = true;
-            Vue.locale(
-                Vue.config.lang,
-                deepmerge(lang, Vue.locale(Vue.config.lang) || {}, { clone: true })
-            );
-        }
+    const vuei18n = Object.getPrototypeOf(this).$t;
+    if (typeof vuei18n === 'function') {
         return vuei18n.apply(this, arguments);
     }
 };

--- a/test/unit/specs/date-picker.spec.js
+++ b/test/unit/specs/date-picker.spec.js
@@ -77,6 +77,7 @@ describe('DatePicker.vue', () => {
   });
 
   it('should change type progamatically', done => {
+
     vm = createVue({
       template: '<Date-picker :type="dateType"></Date-picker>',
       data() {
@@ -112,12 +113,12 @@ describe('DatePicker.vue', () => {
         })
         .then(() => {
           expect(picker.type).to.equal('date');
-          expect(picker.selectionMode).to.equal('day');
-
+          expect(picker.selectionMode).to.equal('date');
           done();
         });
     });
   });
+
 
   it('should fire `on-change` when reseting value', done => {
     const now = new Date();
@@ -141,7 +142,7 @@ describe('DatePicker.vue', () => {
       expect(displayField.value).to.equal(nowDate);
 
       picker.showClose = true; // to simulate mouseenter in the Input
-      picker.handleIconClick(); // reset the input value
+      picker.handleClear(); // reset the input value
       vm.$nextTick(() => {
         expect(onChangeCalled).to.equal(true);
         expect(displayField.value).to.equal('');

--- a/test/unit/specs/date-picker.spec.js
+++ b/test/unit/specs/date-picker.spec.js
@@ -26,7 +26,31 @@ describe('DatePicker.vue', () => {
     });
   });
 
-  it('should create a DatePicker component of type="datetimerange"', done => {
+  it('should create a DatePicker component and open the calendar with the given month', done => {
+      vm = createVue({
+          template: '<Date-Picker v-model="value"></Date-Picker>',
+          data() {
+              return {
+                  value: '2018-02-05'
+              };
+          }
+      });
+
+      const picker = vm.$children[0];
+      picker.showPicker();
+      vm.$nextTick(() => {
+          const dropdown = picker.$children[1];
+          const panel = dropdown.$children[0];
+
+          expect(panel.month).to.equal(picker.internalValue.getMonth());
+          expect(panel.year).to.equal(picker.internalValue.getFullYear());
+          expect(panel.date.getTime()).to.equal(picker.internalValue.getTime());
+
+          done();
+      });
+  });
+
+    it('should create a DatePicker component of type="datetimerange"', done => {
     vm = createVue(`
       <Date-Picker type="datetimerange"></Date-Picker>
     `);


### PR DESCRIPTION
When we use 

    const panel = getPanel(this.type);
    this.Panel = new Vue(panel);

this has 2 problems:

 - we create a new Vue instance that will not inherit `i18n` settings. We do `new Vue({ i18n }).$mount('#app');` to start the APP and `new Vue(panel);` will not use that.

 - iView should not have `Vue` in dependencies for core code, only internal tests. We have to fix this in separated components, but basically we don't know clients Vue version and we make `this.Panel = new Vue(panel);` use another version of Vue than client is using.

So, this PR removes the `new Vue()` logic on `DatePicker`.

I think this PR is OK to be compliant with `vue-i18n` `7.x` but would like to get feedback and tests first.
