### PR TITLE
Support more types on <i-input>

### DIFF
--- a/src/components/input/input.vue
+++ b/src/components/input/input.vue
@@ -70,7 +70,7 @@
         props: {
             type: {
                 validator (value) {
-                    return oneOf(value, ['text', 'textarea', 'password']);
+                    return oneOf(value, ['text', 'textarea', 'password', 'url', 'email', 'date']);
                 },
                 default: 'text'
             },


### PR DESCRIPTION
Why do you need a validator on `type` value? Is it ok to remove this validator?