### PR TITLE
Fix: Can't clear selectedKeys in Transfer

### DIFF
--- a/src/components/transfer/transfer.vue
+++ b/src/components/transfer/transfer.vue
@@ -215,6 +215,9 @@
                     this.rightCheckedKeys = this.rightData
                             .filter(data => selectedKeys.indexOf(data.key) > -1)
                             .map(data => data.key);
+                } else {
+                    this.leftCheckedKeys = [];
+                    this.rightCheckedKeys = [];
                 }
             },
             moveTo (direction) {
@@ -251,6 +254,9 @@
             },
             data () {
                 this.splitData(false);
+            },
+            selectedKeys () {
+                this.splitSelectedKey();
             }
         },
         mounted () {


### PR DESCRIPTION
表格中的Item使用Modal弹窗调用Transfer组件，选中一项，关闭弹窗，再打开弹窗，无法清空选中项。