### PR TITLE
check for element before using it

### DIFF
--- a/src/components/scroll/scroll.vue
+++ b/src/components/scroll/scroll.vue
@@ -228,8 +228,8 @@
             },
 
             onScroll() {
-                if (this.isLoading) return;
                 const el = this.$refs.scrollContainer;
+                if (this.isLoading || !el) return;
                 const scrollDirection = Math.sign(this.lastScroll - el.scrollTop); // IE has no Math.sign, check that webpack polyfills this
                 const displacement = el.scrollHeight - el.clientHeight - el.scrollTop;
 


### PR DESCRIPTION
I noticed that when a component is destroyed and it is scrolling we get a error because `this.$refs.scrollContainer` is not in DOM  anymore. This fixes that.
