### PR TITLE
fix last column resize bug when no data

### DIFF
--- a/src/components/table/mixin.js
+++ b/src/components/table/mixin.js
@@ -25,7 +25,7 @@ export default {
                 width = this.columnsWidth[column._index].width;
             }
             // when browser has scrollBar,set a width to resolve scroll position bug
-            if (this.columns.length === index + 1 && top && this.$parent.bodyHeight !== 0) {
+            if (width && this.columns.length === index + 1 && top && this.$parent.bodyHeight !== 0) {
                 width += this.$parent.scrollBarWidth;
             }
             // when fixed type,reset first right fixed column's width


### PR DESCRIPTION
If a table has heigth and last column is auto width

``` js
let width = ''
// is_last_column, true && top_always_true && height_set_by_user, true
if ( this.columns.length === index + 1 && top && this.$parent.bodyHeight !== 0) {
    // width will be 0 + this.$parent.scrollBarWidth === this.$parent.scrollBarWidth
    // so last column will be 10~20px(the width of scrollBar)
}
```

there is an example with iview@2.8.0
- [gist](https://gist.github.com/anonymous/e04e86c9e99d4d1e97bf327769acd345)
- [demo on jsbin](http://jsbin.com/soqogagiqu)


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

  