### PR TITLE
New feature: add "clickoutside" event emitter to dropdown

### DIFF
--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="[prefixCls]"
-        v-clickoutside="handleClose"
+        v-clickoutside="onClickoutside"
         @mouseenter="handleMouseenter"
         @mouseleave="handleMouseleave">
         <div :class="[prefixCls + '-rel']" ref="reference" @click="handleClick"><slot></slot></div>
@@ -110,6 +110,10 @@
                         this.currentVisible = false;
                     }, 150);
                 }
+            },
+            onClickoutside (e) {
+                this.handleClose();
+                if (this.currentVisible) this.$emit('on-clickoutside', e);
             },
             handleClose () {
                 if (this.trigger === 'custom') return false;


### PR DESCRIPTION
When a dropdown is in `custom` trigger mode we have no feedback if there is a click outside the dropdown. I think this is useful for the manual control of the dropdown visibility.

Example: https://jsfiddle.net/mdc1792o/3/