### PR TITLE
update Modal set max-height 80% of window height

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -5,8 +5,8 @@
         </transition>
         <div :class="wrapClasses" @click="handleWrapClick">
             <transition :name="transitionNames[0]" @after-leave="animationFinish">
-                <div :class="classes" :style="mainStyles" v-show="visible">
-                    <div :class="[prefixCls + '-content']">
+                <div :class="classes" v-show="visible">
+                    <div :class="[prefixCls + '-content']" :style="mainStyles">
                         <a :class="[prefixCls + '-close']" v-if="closable" @click="close">
                             <slot name="close">
                                 <Icon type="ios-close-empty"></Icon>

--- a/src/styles/components/modal.less
+++ b/src/styles/components/modal.less
@@ -2,11 +2,11 @@
 @confirm-prefix-cls: ~"@{css-prefix}modal-confirm";
 
 .@{modal-prefix-cls} {
+    height: 100%;
     width: auto;
     margin: 0 auto;
     position: relative;
     outline: none;
-    top: 100px;
 
     &-hidden {
         display: none !important;
@@ -34,7 +34,13 @@
     }
 
     &-content {
+        display: flex;
+        flex-direction: column;
         position: relative;
+        top: 100px;
+        left: 50%;
+        transform: translateX(-50%);
+        max-height: 80%;
         background-color: #fff;
         border: 0;
         border-radius: @border-radius-base;
@@ -50,6 +56,8 @@
     }
 
     &-body {
+        flex: 1;
+        overflow-y: auto;
         padding: 16px;
         font-size: 12px;
         line-height: 1.5;


### PR DESCRIPTION
如果Modal的内容过长导致其超出一屏，会在body层产生滚动，footer部分在屏幕外，不够直观。

通过限制Modal的最大高度（比如80%的窗口高度），使modal-body弹性伸缩，且过长时可以自动滚动，可能会更好点;) demo如下：

![long-modal](https://user-images.githubusercontent.com/6861511/35379481-27c2094e-01f1-11e8-89b8-b7de45b5c41f.png)

btw，这种结构下，`ivu-modal-content`可以合并到`ivu-modal`，减少一层标签？
