### PR TITLE
inputNumber增加multiple属性

### DIFF
--- a/src/components/input-number/input-number.vue
+++ b/src/components/input-number/input-number.vue
@@ -111,6 +111,9 @@
             precision: {
                 type: Number
             },
+            multiple: {
+                type: Number
+            },
             elementId: {
                 type: String
             }
@@ -227,6 +230,10 @@
                 this.setValue(val);
             },
             setValue (val) {
+
+                //如果设置了倍数，val是multiple整倍数中最接近输入值且小于输入值的数
+                if (!isNaN(this.multiple)) val = Number(Number(val) - (Number(val) % Number(this.multiple)));
+
                 // 如果 step 是小数，且没有设置 precision，是有问题的
                 if (!isNaN(this.precision)) val = Number(Number(val).toFixed(this.precision));
 


### PR DESCRIPTION
Add ‘multiple’ props to InputNumber.
example: I need even number only, so set multiple = 2.

（给InputNumber组件增加一个属性multiple，使用场景：只允许输入3的倍数，那么设置multiple=3，只允许偶数，那么设置multiple=2。有很多需求会要用到这个属性，比如给11个员工分配物品3，物品的数量要是11的整数才可以通过）
