### PR TITLE
添加多级菜单组件 MultiMenu

### DIFF
--- a/examples/app.vue
+++ b/examples/app.vue
@@ -42,6 +42,7 @@ li + li { border-left: solid 1px #bbb; padding-left: 10px; margin-left: 10px; }
                 <li><router-link to="/dropdown">Dropdown</router-link></li>
                 <li><router-link to="/breadcrumb">Breadcrumb</router-link></li>
                 <li><router-link to="/menu">Menu</router-link></li>
+                <li><router-link to="/multi-menu">MultiMenu</router-link></li>
                 <li><router-link to="/spin">Spin</router-link></li>
                 <li><router-link to="/cascader">Cascader</router-link></li>
                 <li><router-link to="/select">Select</router-link></li>

--- a/examples/main.js
+++ b/examples/main.js
@@ -135,6 +135,10 @@ const router = new VueRouter({
             component: (resolve) => require(['./routers/menu.vue'], resolve)
         },
         {
+            path: '/multi-menu',
+            component: (resolve) => require(['./routers/multi-menu.vue'], resolve)
+        },
+        {
             path: '/spin',
             component: (resolve) => require(['./routers/spin.vue'], resolve)
         },

--- a/examples/routers/multi-menu.vue
+++ b/examples/routers/multi-menu.vue
@@ -1,0 +1,94 @@
+<template>
+    <div>
+        <MultiMenu :config="config" :data="data" @on-select="handleSelect" @on-open-change="handleOpen">
+        </MultiMenu>
+        <br>
+        <p>切换主题</p>
+        <Radio-group v-model="config.theme">
+            <Radio label="light"></Radio>
+            <Radio label="dark"></Radio>
+            <Radio label="primary"></Radio>
+        </Radio-group>
+        <Input v-model="value4" icon="ios-clock-outline" placeholder="请输入..." style="width: 200px"></Input>
+    </div>
+</template>
+<script>
+    export default {
+        data () {
+            return {
+                config: {
+                    theme: 'dark',
+                    'active-name': '1',
+                    accordion: true,
+                    'open-names': ['3', '3-3', '3-3-3'],
+                },
+                data: [
+                    { name: '1', icon: 'ios-paper', title: '一级1', },
+                    { name: '2', icon: 'ios-people', title: '一级2', },
+                    { 
+                        name: '3', icon: 'ios-people', title: '一级2', 
+                        children: [
+                            { name: '3-1', title: '二级1', },
+                            { name: '3-2', title: '二级2', },
+                            {
+                                name: '3-3', icon: 'stats-bars', title: '二级3',
+                                children: [
+                                    { name: '3-3-1', title: '三级1', },
+                                    { name: '3-3-2', title: '三级2', },
+                                    {
+                                        name: '3-3-3', icon: 'stats-bars', title: '三级3',
+                                        children: [
+                                            { name: '3-3-3-1', title: '四级1', },
+                                            { name: '3-3-3-2', title: '四级2', },
+                                            {
+                                                title: 'Menu-Group',
+                                                groups: [
+                                                    { name: '3-3-3-3-1', icon: 'document-text', title: 'Group-item1', },
+                                                    { name: '3-3-3-3-2', icon: 'chatbubbles', title: 'Group-item2', },
+                                                    { 
+                                                        name: '3-3-3-3-3',
+                                                        // icon: 'chatbubbles',
+                                                        title: 'Group-item3',
+                                                        children: [
+                                                            { name: '3-3-3-3-3-1', title: 'Group-item2 1'}
+                                                        ]
+                                                    },
+                                                ]
+                                            }
+                                        ]
+                                    }, {
+                                        name: '3-3-4', icon: 'stats-bars', title: '三级4',
+                                        children: [
+                                            { name: '3-3-4-1', title: '四级1', },
+                                            { name: '3-3-4-2', title: '四级2', },
+                                        ]
+                                    }
+                                ]
+                            }, {
+                                name: '3-4', icon: 'stats-bars', title: '二级4',
+                                children: [
+                                    { name: '3-4-1', title: '三级1', },
+                                    { name: '3-4-2', title: '三级2', },
+                                ]
+                            }
+                        ]
+                    },
+                    { name: '4', icon: 'settings', title: '一级4', },
+                ],
+                theme1: 'dark',
+                value4: '',
+                openArr: ['3', '3-3', '3-3-3']
+            };
+        },
+        methods: {
+            handleSelect (name) {
+                console.log(name);
+                return name;
+            },
+            handleOpen (openArr) {
+                console.log(openArr);
+                return openArr;
+            }
+        }
+    };
+</script>

--- a/src/components/multi-menu/index.js
+++ b/src/components/multi-menu/index.js
@@ -1,0 +1,3 @@
+import MultiMenu from './multi-menu.vue';
+
+export default MultiMenu;

--- a/src/components/multi-menu/multi-menu.vue
+++ b/src/components/multi-menu/multi-menu.vue
@@ -18,7 +18,7 @@ let getObject = (list, obj) => {
         }
     }
     return ans;
-}
+};
 export default {
     name: 'MultiMenu',
     props: {
@@ -55,7 +55,6 @@ export default {
         },
         getTemplate(h, data) {
             let child = [];
-            let contentCnt = 0;
             if (data.icon) {
                 child.push(h('Icon', {
                     props: {
@@ -65,7 +64,7 @@ export default {
             }
             child.push(data.title ? data.title : '');
             return h('template', {
-                slot: "title"
+                slot: 'title'
             }, child, child.length - 1);
         },
         getMenuGroup(h, data) {
@@ -85,12 +84,12 @@ export default {
             }, child);
         },
         getSubMenu(h, data) {
-            let props = getObject(['name'], data)
+            let props = getObject(['name'], data);
             let child = [];
             if (data.icon || data.title) {
                 child.push(this.getTemplate(h, data));
             }
-            child.push(...this.getChildren(h, data.children))
+            child.push(...this.getChildren(h, data.children));
             return h('SubMenu', {
                 props: props,
             }, child);
@@ -116,5 +115,5 @@ export default {
         let ans = this.getMenu(h, this.data);
         return ans;
     },
-}
+};
 </script>

--- a/src/components/multi-menu/multi-menu.vue
+++ b/src/components/multi-menu/multi-menu.vue
@@ -1,0 +1,120 @@
+<!--
+@Author: chenhuachao <chc>
+@Date:   2018-01-25T17:12:44+08:00
+@Email:  chenhuachaoxyz@gmail.com
+@Filename: multi-menu.vue
+@Last modified by:   chc
+@Last modified time: 2018-01-26T15:18:16+08:00
+@License: MIT
+@Copyright: 2018
+-->
+<script>
+import Menu from '../menu';
+let getObject = (list, obj) => {
+    let ans = {};
+    for(let i = 0;i < list.length; i++) {
+        if(obj.hasOwnProperty(list[i])) {
+            ans[list[i]] = obj[list[i]];
+        }
+    }
+    return ans;
+}
+export default {
+    name: 'MultiMenu',
+    props: {
+        data: {
+            type: Array,
+            default: [],
+        },
+        config: {
+            type: Object,
+            default: {},
+        }
+    },
+    components: {
+        'Menu': Menu,
+        'SubMenu': Menu.Sub,
+        'MenuGroup': Menu.Group,
+        'MenuItem': Menu.Item,
+    },
+    methods: {
+        getChildren(h, data) {
+            let list = [];
+            if (data && data.length) {
+                for (let i = 0;i < data.length; i++) {
+                    if (data[i].groups) {
+                        list.push(this.getMenuGroup(h, data[i]));
+                    } else if (data[i].children) {
+                        list.push(this.getSubMenu(h, data[i]));
+                    } else {
+                        list.push(this.getMenuItem(h, data[i]));
+                    }
+                }
+            }
+            return list;
+        },
+        getTemplate(h, data) {
+            let child = [];
+            let contentCnt = 0;
+            if (data.icon) {
+                child.push(h('Icon', {
+                    props: {
+                        type: data.icon,
+                    }
+                }));
+            }
+            child.push(data.title ? data.title : '');
+            return h('template', {
+                slot: "title"
+            }, child, child.length - 1);
+        },
+        getMenuGroup(h, data) {
+            let props = getObject(['title'], data);
+            let child = [];
+            child.push(...this.getChildren(h, data.groups));
+            return h('MenuGroup', {
+                props: props,
+            }, child);
+        },
+        getMenuItem(h, data) {
+            let props = getObject(['name'], data);
+            let child = [];
+            child.push(data.title ? data.title : '');
+            return h('MenuItem', {
+                props: props,
+            }, child);
+        },
+        getSubMenu(h, data) {
+            let props = getObject(['name'], data)
+            let child = [];
+            if (data.icon || data.title) {
+                child.push(this.getTemplate(h, data));
+            }
+            child.push(...this.getChildren(h, data.children))
+            return h('SubMenu', {
+                props: props,
+            }, child);
+        },
+        getMenu(h, data) {
+            let list = data;
+            let child = [];
+            child.push(...this.getChildren(h, list));
+            return h('Menu', {
+                props: this.config,
+                on: {
+                    'on-select': (name) => {
+                        this.$emit('on-select', name);
+                    },
+                    'on-open-change': (name) => {
+                        this.$emit('on-open-change', name);
+                    }
+                }
+            }, child);
+        },
+    },
+    render: function (h) {
+        let ans = this.getMenu(h, this.data);
+        return ans;
+    },
+}
+</script>

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import Scroll from './components/scroll';
 import Layout from './components/layout';
 import LoadingBar from './components/loading-bar';
 import Menu from './components/menu';
+import MultiMenu from './components/multi-menu';
 import Message from './components/message';
 import Modal from './components/modal';
 import Notice from './components/notice';
@@ -92,6 +93,7 @@ const components = {
     Menu,
     MenuGroup: Menu.Group,
     MenuItem: Menu.Item,
+    MultiMenu,
     Message,
     Modal,
     Notice,


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

+ 对原有的 `Menu`，`SubMenu`，`MenuGroup`，`MenuItem` 组件进行相关组合成的单组件 `MultiMenu`
+ `props` 参数有两个: `config` 和 `data`
    + `config` 是一个 `object`，支持原有的 [menu_props](https://www.iviewui.com/components/menu#Menu_props) 配置
    + `data` 是一个数组，数组的每一项是一个
 `Object` , 包含 `title`, `name`, `icon`, `children`, `groups`
+ 使用方式详见 [examples/routers/multi-menu.vue](https://github.com/iview/iview/commit/6da6f641d314e9a6dab39819234e507022881188#diff-6d1c55e5e1f8bbaebb78e75cbff7cc2e)