### PR TITLE
Fix #982 issue.Make Null acceptable for Select tag（让Select标签可以接收null值）

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -724,7 +724,8 @@
         watch: {
             value (val) {
                 this.model = val;
-                if (val === '') this.query = '';
+                // #982
+                if (val === '' || val === null) this.query = '';
             },
             label (val) {
                 this.currentLabel = val;


### PR DESCRIPTION
Fix #982 issue.Make Null acceptable for Select tag（让Select标签可以接收null值）

Sometimes the Select tag in From defaults null, it won't reset empty where trigger 'resetFields' method.The pull request attempt to solve the issue.

有的时候Form中Select控件的默认值是null，这个时候调用resetFields会导致Select不会清空。本次提交为了解决这个问题。