### PR TITLE
Use babel-polyfill for testing examples

### DIFF
--- a/examples/main.js
+++ b/examples/main.js
@@ -1,12 +1,13 @@
 /**
  * Created by aresn on 16/6/20.
  */
+import 'babel-polyfill';
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 import App from './app.vue';
 import iView from '../src/index';
-// import locale from '../src/locale/lang/en-US';
-import locale from '../src/locale/lang/zh-CN';
+import locale from '../src/locale/lang/en-US';
+// import locale from '../src/locale/lang/zh-CN';
 
 Vue.use(VueRouter);
 Vue.use(iView, { locale });


### PR DESCRIPTION
(Polyfill) This is required when developing with older browser i.e. IE11.

The locale change is because it is really difficult for non-chinese reading/speaking developers to understand what they are seeing on the page when developing this project.


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
