### PR TITLE
Use constant component names in Pascal Case as per vue standards

### DIFF
--- a/src/components/form/formItemName.js
+++ b/src/components/form/formItemName.js
@@ -1,0 +1,1 @@
+export default 'FormItem';

--- a/src/components/form/formName.js
+++ b/src/components/form/formName.js
@@ -1,0 +1,1 @@
+export default 'IForm';

--- a/src/components/form/formName.js
+++ b/src/components/form/formName.js
@@ -1,1 +1,1 @@
-export default 'IForm';
+export default 'iForm';

--- a/src/components/select/dropdownName.js
+++ b/src/components/select/dropdownName.js
@@ -1,0 +1,1 @@
+export default 'Drop';

--- a/src/components/select/optionGroupName.js
+++ b/src/components/select/optionGroupName.js
@@ -1,0 +1,1 @@
+export default 'OptionGroup';

--- a/src/components/select/optionName.js
+++ b/src/components/select/optionName.js
@@ -1,1 +1,1 @@
-export default 'IOption';
+export default 'iOption';

--- a/src/components/select/optionName.js
+++ b/src/components/select/optionName.js
@@ -1,0 +1,1 @@
+export default 'IOption';

--- a/src/components/select/selectName.js
+++ b/src/components/select/selectName.js
@@ -1,1 +1,1 @@
-export default 'ISelect';
+export default 'iSelect';

--- a/src/components/select/selectName.js
+++ b/src/components/select/selectName.js
@@ -1,0 +1,1 @@
+export default 'ISelect';


### PR DESCRIPTION
While using Pascal Case for names will not be breaking within iview itself, there is the possibility that users are searching these names in there own code.

https://vuejs.org/v2/style-guide/#Single-file-component-filename-casing-strongly-recommended

Further reasons for splitting these out are that if you begin to use https://github.com/vuejs/eslint-plugin-vue for the project then eslint will automatically correct these to Pascal Case. If you choose to continue using a small `i` for component names then eslint will not touch these files. External users can also reference these constants in their code without the fear of any future changes in component names. This would ideally be done for all components in iview in the future, this PR just deals with the rework of the select component and its touch point form.

<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
