### PR TITLE
Use constant for CSS prefixes

### DIFF
--- a/src/components/select/prefixCls.js
+++ b/src/components/select/prefixCls.js
@@ -1,0 +1,9 @@
+import {
+    IVU,
+    SELECT,
+} from '@/utils/constants';
+import {
+    kebabJoin,
+} from '@/utils/assist';
+
+export default kebabJoin(IVU, SELECT);


### PR DESCRIPTION
Composed string that can be used within iview and by users of the library.


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
