### PR TITLE
Remove global list-style reset

### DIFF
--- a/src/styles/common/base.less
+++ b/src/styles/common/base.less
@@ -31,11 +31,6 @@ button, input, select, textarea {
     line-height: inherit;
 }
 
-ul,
-ol {
-    list-style: none;
-}
-
 input::-ms-clear, input::-ms-reveal {
     display: none;
 }


### PR DESCRIPTION
In https://github.com/iview/iview/blob/v2.9.2/src/styles/common/base.less#L34-L37 iview resets the global style for `<li>` tags. This is being applied to the global CSS of projects using iview. This CSS is already being used in specific components that need it.

This should not be global, if we find some use case that needs this we can patch that specific component or add a class in this reset to make it scoped and not global.