### PR TITLE
Use last picked date in multiple mode for panel date

### DIFF
--- a/src/components/date-picker/panel/Date/date.vue
+++ b/src/components/date-picker/panel/Date/date.vue
@@ -92,7 +92,11 @@
         mixins: [ Mixin, Locale, DateMixin ],
         components: { Icon, DateTable, YearTable, MonthTable, TimePicker, Confirm, datePanelLabel },
         props: {
-            // in the mixin
+            // more props in the mixin
+            multiple: {
+                type: Boolean,
+                default: false
+            }
         },
         data () {
             const {selectionMode, value} = this;
@@ -141,7 +145,7 @@
         watch: {
             value (newVal) {
                 this.dates = newVal;
-                this.panelDate = this.startDate || this.dates[0] || new Date();
+                this.panelDate = this.startDate || (this.multiple ? this.dates[this.dates.length - 1] : this.dates[0]) || new Date();
             },
             currentView (currentView) {
                 this.$emit('on-selection-mode-change', currentView);

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -198,6 +198,7 @@
             publicStringValue(){
                 const {formatDate, publicVModelValue, type} = this;
                 if (type.match(/^time/)) return publicVModelValue;
+                if (this.multiple) return formatDate(publicVModelValue);
                 return Array.isArray(publicVModelValue) ? publicVModelValue.map(formatDate) : formatDate(publicVModelValue);
             },
             opened () {

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -47,6 +47,7 @@
                         :split-panels="splitPanels"
                         :show-week-numbers="showWeekNumbers"
                         :picker-type="type"
+                        :multiple="multiple"
 
                         :time-picker-options="timePickerOptions"
 


### PR DESCRIPTION
When in multiple mode picking, the date used for the days table was always the first in the dates array, this changes to the last picked date instead.