### PR TITLE
correct list-style of groups

### DIFF
--- a/src/styles/components/select.less
+++ b/src/styles/components/select.less
@@ -191,6 +191,10 @@
     &-multiple .@{css-prefix}tag{
         margin: 3px 4px 2px 0;
     }
+
+    &-dropdown-list {
+        list-style: none;
+    }
 }
 
 .select-item(@select-prefix-cls, @select-item-prefix-cls);


### PR DESCRIPTION
Loos like the groups list was using the global CSS we removed in https://github.com/iview/iview/pull/3061

![skarmavbild 2018-03-08 kl 21 11 50](https://user-images.githubusercontent.com/5614559/37174455-d40733f0-2316-11e8-8694-f76288df07ae.png)
