### PR TITLE
Fix: dist.dev need to use production sourcemaps not development

### DIFF
--- a/build/webpack.dist.dev.config.js
+++ b/build/webpack.dist.dev.config.js
@@ -6,7 +6,7 @@ const webpackBaseConfig = require('./webpack.base.config.js');
 process.env.NODE_ENV = 'production';
 
 module.exports = merge(webpackBaseConfig, {
-    devtool: 'eval-source-map',
+    devtool: 'source-map',
 
     entry: {
         main: './src/index.js'


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
