### PR TITLE
add props input-size

### DIFF
--- a/src/components/slider/slider.vue
+++ b/src/components/slider/slider.vue
@@ -3,6 +3,7 @@
         <Input-number
             v-if="!range && showInput"
             :min="min"
+            :size="inputSize"
             :max="max"
             :step="step"
             :value="exportValue[0]"
@@ -119,6 +120,13 @@
             showInput: {
                 type: Boolean,
                 default: false
+            },
+            inputSize: {
+                type: String,
+                default: 'default',
+                validator (value) {
+                    return oneOf(value, ['small', 'large', 'default']);
+                }
             },
             showStops: {
                 type: Boolean,


### PR DESCRIPTION
表单布局中包含slider时，input 样式无法统一。
或者考虑 允许 `showInput` 的值为 `String`。控制input的size。