### PR TITLE
优化tabs组件

### DIFF
--- a/examples/routers/tabs.vue
+++ b/examples/routers/tabs.vue
@@ -159,7 +159,20 @@
 
 <template>
     <Tabs type="card">
-        <TabPane v-for="tab in tabs" :key="tab" :label="'标签' + tab">标签{{ tab }}</TabPane>
+        <TabPane v-for="tab in tabs" :key="tab" :label="'标签' + tab">
+            <span v-if="tab==1">
+                <p>标签1</p>
+                <p>标签1</p>
+                <p>标签1</p>
+                <p>标签1</p>
+                <p>标签1</p>
+                <p>标签1</p>
+                <p>标签1</p>
+                <p>标签1</p>
+                <p>标签1</p>
+            </span>
+            <span v-else>标签{{ tab }}</span>
+        </TabPane>
         <Button type="ghost" @click="handleTabsAdd" size="small" slot="extra">增加</Button>
     </Tabs>
 </template>
@@ -177,5 +190,11 @@
         }
     }
 </script>
+<style lang="postcss" scoped>
+p {
+    margin-bottom: 50px; 
+}
+</style>
+
 
 

--- a/src/components/tabs/pane.vue
+++ b/src/components/tabs/pane.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="prefixCls" v-show="show"><slot></slot></div>
+    <div :class="paneClasses" v-show="show"><slot></slot></div>
 </template>
 <script>
     const prefixCls = 'ivu-tabs-tabpane';
@@ -58,6 +58,17 @@
         },
         destroyed () {
             this.updateNav();
+        },
+        computed: {
+            paneClasses() {
+                return [
+                    `${prefixCls}`,
+                    {
+                        [`${prefixCls}-active`]: this.$parent.activeKey == this.currentName,
+                        [`${prefixCls}-inactive`]: this.$parent.activeKey != this.currentName
+                    }
+                ]
+            }
         }
     };
 </script>

--- a/src/styles/components/tabs.less
+++ b/src/styles/components/tabs.less
@@ -163,6 +163,7 @@
         .@{tabs-prefix-cls}-tabpane-inactive {
             opacity: 0;
             height: 0;
+            pointer-events: none;
         }
     }
 


### PR DESCRIPTION
tabs组件存在这样的问题：
所有的tabpane内容的高度都是相同的，就是当有一个tabpane的内容足够多甚至撑出了滚动条，但是其他的tabpane内容极少，可是高度有保持和最高的tabpane一致，就会导致出现很多留白的位置。
![image](https://user-images.githubusercontent.com/20440496/38450768-25cde886-3a56-11e8-8a62-49c853611dcc.png)

![image](https://user-images.githubusercontent.com/20440496/38450797-a579154c-3a56-11e8-9b17-a65e973872cc.png)



