### PR TITLE
Expose changed date component

### DIFF
--- a/src/components/date-picker/panel/Date/date-range.vue
+++ b/src/components/date-picker/panel/Date/date-range.vue
@@ -317,7 +317,7 @@
                     this.changePanelDate(otherPanel, 'Month', 1, false);
                 }
             },
-            handleRangePick (val) {
+            handleRangePick (val, type) {
                 if (this.rangeState.selecting || this.currentView === 'time'){
                     if (this.currentView === 'time'){
                         this.dates = val;
@@ -330,7 +330,7 @@
                             selecting: false
                         };
                     }
-                    this.handleConfirm(false);
+                    this.handleConfirm(false, type || 'date');
                 } else {
                     this.rangeState = {
                         from: val,

--- a/src/components/date-picker/panel/Date/date.vue
+++ b/src/components/date-picker/panel/Date/date.vue
@@ -188,14 +188,14 @@
                 else this.pickerTable = this.getTableType(this.currentView);
 
             },
-            handlePick (value) {
+            handlePick (value, type) {
                 const {selectionMode, panelDate} = this;
                 if (selectionMode === 'year') value = new Date(value.getFullYear(), 0, 1);
                 else if (selectionMode === 'month') value = new Date(panelDate.getFullYear(), value.getMonth(), 1);
                 else value = new Date(value);
 
                 this.dates = [value];
-                this.$emit('on-pick', value);
+                this.$emit('on-pick', value, false, type || selectionMode);
             },
         },
     };

--- a/src/components/date-picker/panel/Time/time-range.vue
+++ b/src/components/date-picker/panel/Time/time-range.vue
@@ -142,7 +142,7 @@
                 // judge endTime > startTime?
                 if (dateEnd < dateStart) dateEnd = dateStart;
 
-                if (emit) this.$emit('on-pick', [dateStart, dateEnd], true);
+                if (emit) this.$emit('on-pick', [dateStart, dateEnd], 'time');
             },
             handleStartChange (date) {
                 this.handleChange(date, {});

--- a/src/components/date-picker/panel/Time/time.vue
+++ b/src/components/date-picker/panel/Time/time.vue
@@ -135,7 +135,7 @@
                     type => newDate[`set${capitalize(type)}`](date[type])
                 );
 
-                if (emit) this.$emit('on-pick', newDate, true);
+                if (emit) this.$emit('on-pick', newDate, 'time');
             },
         },
         mounted () {

--- a/src/components/date-picker/panel/panel-mixin.js
+++ b/src/components/date-picker/panel/panel-mixin.js
@@ -44,8 +44,8 @@ export default {
             this.handleConfirm();
             //  if (this.showTime) this.$refs.timePicker.handleClear();
         },
-        handleConfirm(visible) {
-            this.$emit('on-pick', this.dates, visible);
+        handleConfirm(visible, type) {
+            this.$emit('on-pick', this.dates, visible, type || this.type);
         },
         onToggleVisibility(open){
             const {timeSpinner, timeSpinnerEnd} = this.$refs;

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -272,7 +272,7 @@
                 const isValidDate = newDate.reduce((valid, date) => valid && date instanceof Date, true);
 
                 if (newValue !== oldValue && !isDisabled && isValidDate) {
-                    this.emitChange();
+                    this.emitChange(this.type);
                     this.internalValue = newDate;
                 } else {
                     this.forceInputRerender++;
@@ -299,7 +299,7 @@
                 this.internalValue = this.internalValue.map(() => null);
                 this.$emit('on-clear');
                 this.dispatch('FormItem', 'on-form-change', '');
-                this.emitChange();
+                this.emitChange(this.type);
                 this.reset();
 
                 setTimeout(
@@ -307,9 +307,9 @@
                     500 // delay to improve dropdown close visual effect
                 );
             },
-            emitChange () {
+            emitChange (type) {
                 this.$nextTick(() => {
-                    this.$emit('on-change', this.publicStringValue);
+                    this.$emit('on-change', this.publicStringValue, type);
                     this.dispatch('FormItem', 'on-form-change', this.publicStringValue);
                 });
             },
@@ -366,7 +366,7 @@
                     return formatter(value, this.format || format);
                 }
             },
-            onPick(dates, visible = false) {
+            onPick(dates, visible = false, type) {
                 if (this.multiple){
                     const pickedTimeStamp = dates.getTime();
                     const indexOfPickedDate = this.internalValue.findIndex(date => date && date.getTime() === pickedTimeStamp);
@@ -379,7 +379,7 @@
 
                 if (!this.isConfirm) this.onSelectionModeChange(this.type); // reset the selectionMode
                 if (!this.isConfirm) this.visible = visible;
-                this.emitChange();
+                this.emitChange(type);
             },
             onPickSuccess(){
                 this.visible = false;


### PR DESCRIPTION
(New Feature)

When we use the `@on-change` event in `DatePicker` we get only a new string `dddd-mm-yy hh:mm:ss` in the functions 1st argument. This change adds a new argument so we can know what was changed, if the `date` or the `time` in case of `datetime` picker. 

Test case:

```
<template>
    <div style="width: 500px;margin: 100px;">
        <date-picker type="date" @on-change="onChange"></date-picker>
    </div>
</template>
<script>
    export default {
        methods: {
            onChange(...args){
                console.log(...args);
            }
        }
    }
</script>

```