### PR TITLE
实现InputNumber获取焦点时选中已有值，增加on-focus的返回值event。

### DIFF
--- a/examples/routers/input-number.vue
+++ b/examples/routers/input-number.vue
@@ -48,6 +48,8 @@
         
         <InputNumber v-model="valueNull" @on-change="change" style="width: 200px"></InputNumber>
         <InputNumber v-model="valueNull" @on-change="change" :formatter="formatter" :parser="parser" style="width: 200px"></InputNumber>
+                
+        <InputNumber v-model="value2" @on-focus="focus" style="width: 200px"></InputNumber>
     </div>
 </template>
 <script>
@@ -64,6 +66,9 @@
             }
         },
         methods: {
+            focus (e) {
+                e.target.select()
+            },
             change (v) {
                 console.log(v)
             }

--- a/src/components/input-number/input-number.vue
+++ b/src/components/input-number/input-number.vue
@@ -26,6 +26,7 @@
                 @blur="blur"
                 @keydown.stop="keyDown"
                 @input="change"
+                @mouseup="preventDefault"
                 @change="change"
                 :readonly="readonly || !editable"
                 :name="name"

--- a/src/components/input-number/input-number.vue
+++ b/src/components/input-number/input-number.vue
@@ -250,9 +250,9 @@
                     this.dispatch('FormItem', 'on-form-change', val);
                 });
             },
-            focus () {
+            focus (event) {
                 this.focused = true;
-                this.$emit('on-focus');
+                this.$emit('on-focus', event);
             },
             blur () {
                 this.focused = false;


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
在on-focus事件中增加返回值event，使用组件时即可 `event.target.select()` 选中已有值。

在safari浏览器中，需要增加设置mouseup事件preventDefault才能实现。
在chrome浏览器中，可以不需要设置mouseup事件preventDefault。
其余浏览器未测试。