### PR TITLE
Fix race condition for changing "currentValue"

### DIFF
--- a/src/components/slider/slider.vue
+++ b/src/components/slider/slider.vue
@@ -169,7 +169,7 @@
         watch: {
             value (val) {
                 val = this.checkLimits(Array.isArray(val) ? val : [val]);
-                if (val[0] !== this.currentValue[0] || val[1] !== this.currentValue[1]) {
+                if (!this.dragging && (val[0] !== this.currentValue[0] || val[1] !== this.currentValue[1])) {
                     this.currentValue = val;
                 }
             },


### PR DESCRIPTION
One real world example, when using the `Slider` component as the audio play progress bar, the `value/currentValue` could be updated by listening the `timeupdate` event of the audio element or by user dragging interaction, but user interaction should have higher priority over the `timeupdate` event.


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
