### PR TITLE
badge组件增加type属性，通过设置为'primary', 'info', 'success', 'warning', 'error'等值，可以设置徽标背景颜色

### DIFF
--- a/examples/routers/badge.vue
+++ b/examples/routers/badge.vue
@@ -18,6 +18,43 @@
             <a href="#" class="demo-badge"></a>
         </Badge>
         <Button @click="setCount">set count</Button>
+
+        <Badge :count="1" type="primary">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+        <Badge dot type="primary">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+
+        <Badge :count="2" type="info">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+        <Badge dot type="info">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+
+        <Badge :count="3" type="success">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+        <Badge dot type="success">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+
+        <Badge :count="4" type="warning">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+        <Badge dot type="warning">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+
+        
+        <Badge :count="5" type="error">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+        <Badge dot type="error">
+            <a href="#" class="demo-badge"></a>
+        </Badge>
+
     </div>
 </template>
 <script>

--- a/src/components/badge/badge.vue
+++ b/src/components/badge/badge.vue
@@ -9,8 +9,10 @@
     </span>
 </template>
 <script>
-    const prefixCls = 'ivu-badge';
+   import { oneOf } from '../../utils/assist';
 
+    const prefixCls = 'ivu-badge';
+  
     export default {
         name: 'Badge',
         props: {
@@ -23,21 +25,29 @@
                 type: [Number, String],
                 default: 99
             },
-            className: String
+            className: String,
+            type: {
+                validator (value) {
+                    return oneOf(value, ['primary', 'info', 'success', 'warning', 'error']);
+                }
+            },
         },
         computed: {
             classes () {
                 return `${prefixCls}`;
             },
             dotClasses () {
-                return `${prefixCls}-dot`;
+                return [`${prefixCls}-dot`,{
+                    [`${prefixCls}-dot-${this.type}`]: !!this.type,
+                }];
             },
             countClasses () {
                 return [
                     `${prefixCls}-count`,
                     {
                         [`${this.className}`]: !!this.className,
-                        [`${prefixCls}-count-alone`]: this.alone
+                        [`${prefixCls}-count-alone`]: this.alone,
+                        [`${prefixCls}-count-${this.type}`]: !!this.type,
                     }
                 ];
             },

--- a/src/styles/components/badge.less
+++ b/src/styles/components/badge.less
@@ -37,6 +37,26 @@
             position: relative;
             transform: translateX(0);
         }
+
+        &-primary{
+            background-color: @primary-color
+        };
+
+        &-primary{
+            background-color: @primary-color
+        };
+        &-info{
+            background-color: @info-color
+        };
+        &-success{
+            background-color: @success-color
+        };
+        &-warning{
+            background-color: @warning-color
+        };
+        &-error{
+            background-color: @error-color
+        };
     }
 
     &-dot {
@@ -51,5 +71,21 @@
         background: @error-color;
         z-index: 10;
         box-shadow: 0 0 0 1px #fff;
+
+        &-primary{
+            background-color: @primary-color
+        };
+        &-info{
+            background-color: @info-color
+        };
+        &-success{
+            background-color: @success-color
+        };
+        &-warning{
+            background-color: @warning-color
+        };
+        &-error{
+            background-color: @error-color
+        };
     }
 }


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
