### PR TITLE
修复autoComplete的on-change事件的bug

### DIFF
--- a/src/components/auto-complete/auto-complete.vue
+++ b/src/components/auto-complete/auto-complete.vue
@@ -124,7 +124,9 @@
         },
         watch: {
             value (val) {
-                this.disableEmitChange = true;
+                if(this.currentValue !== val){
+                    this.disableEmitChange = true;
+                }
                 this.currentValue = val;
             },
             currentValue (val) {


### PR DESCRIPTION
当使用v-model绑定value的时候on-change事件只会在第一次触发。


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
