### PR TITLE
修复RadioGroup只能在使用v-model绑定的情况下才能正常使用的bug。

### DIFF
--- a/src/components/radio/radio-group.vue
+++ b/src/components/radio/radio-group.vue
@@ -82,7 +82,7 @@
         },
         watch: {
             value () {
-                if(this.currentValue !== this.value;){
+                if(this.currentValue !== this.value){
                     this.currentValue = this.value;
                     this.updateValue();
                 }

--- a/src/components/radio/radio-group.vue
+++ b/src/components/radio/radio-group.vue
@@ -67,7 +67,7 @@
                 this.childrens = findComponentsDownward(this, 'Radio');
                 if (this.childrens) {
                     this.childrens.forEach(child => {
-                        child.currentValue = this.value === child.label;
+                        child.currentValue = this.currentValue === child.label;
                         child.group = true;
                     });
                 }
@@ -82,8 +82,10 @@
         },
         watch: {
             value () {
-                this.currentValue = this.value;
-                this.updateValue();
+                if(this.currentValue !== this.value;){
+                    this.currentValue = this.value;
+                    this.updateValue();
+                }
             }
         }
     };


### PR DESCRIPTION
使用:value绑定的时候，RadioGroup并不能正常切换。


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
