### PR TITLE
修改Tag组件事件处理机制

### DIFF
--- a/src/components/tag/tag.vue
+++ b/src/components/tag/tag.vue
@@ -1,12 +1,12 @@
 <template>
     <transition name="fade" v-if="fade">
-        <div :class="classes" @click.stop="check" :style="wraperStyles">
+        <div :class="classes" @click="check" :style="wraperStyles">
             <span :class="dotClasses" v-if="showDot" :style="bgColorStyle"></span>
             <span :class="textClasses" :style="textColorStyle"><slot></slot></span>
             <Icon v-if="closable" :class="iconClass" :color="lineColor" type="ios-close-empty" @click.native.stop="close"></Icon>
         </div>
     </transition>
-    <div v-else :class="classes" @click.stop="check" :style="wraperStyles">
+    <div v-else :class="classes" @click="check" :style="wraperStyles">
         <span :class="dotClasses" v-if="showDot" :style="bgColorStyle"></span>
         <span :class="textClasses" :style="textColorStyle"><slot></slot></span>
         <Icon v-if="closable" :class="iconClass" :color="lineColor" type="ios-close-empty" @click.native.stop="close"></Icon>


### PR DESCRIPTION
### 修改tag组件事件处理机制
Tag组件点击close图标进行删除时阻止事件冒泡是正确的，但是Tag组件整体不应该阻止事件冒泡。在某些业务下我需要监控tag外的click事件。

例如：
```
<span @click="handleClick">
  <Tag>iview</Tag>
</span>

handleClick ...
```