### PR TITLE
Fix Bug: Menu.vue (issue: #3575)

### DIFF
--- a/src/components/menu/menu.vue
+++ b/src/components/menu/menu.vue
@@ -92,6 +92,8 @@
                             if (i >= 0) names.splice(i, 1);
                         });
                         names.push(name);
+                    }else {
+                      names.push(name);
                     }
                 }
                 this.openedNames = names;


### PR DESCRIPTION
[issue#3575](https://github.com/iview/iview/issues/3575)

The bug occurs because the accordion pattern is processed and the return does not match the expected value. name has not been push to names,so openedNames is not match the expected.

fix bug  in updateOpenKeys methods