### PR TITLE
Correct time layout when showing week numbers

### DIFF
--- a/src/components/date-picker/panel/Date/date-range.vue
+++ b/src/components/date-picker/panel/Date/date-range.vue
@@ -6,7 +6,7 @@
                 v-for="shortcut in shortcuts"
                 @click="handleShortcutClick(shortcut)">{{ shortcut.text }}</div>
         </div>
-        <div :class="[prefixCls + '-body']">
+        <div :class="panelBodyClasses">
             <div :class="[prefixCls + '-content', prefixCls + '-content-left']" v-show="!isTime">
                 <div :class="[datePrefixCls + '-header']" v-show="currentView !== 'time'">
                     <span
@@ -170,6 +170,15 @@
                         [`${datePrefixCls}-with-week-numbers`]: this.showWeekNumbers
                     }
                 ];
+            },
+            panelBodyClasses(){
+                return [
+                    prefixCls + '-body',
+                    {
+                        [prefixCls + '-body-time']: this.showTime,
+                        [prefixCls + '-body-date']: !this.showTime,
+                    }
+                ]
             },
             leftDatePanelLabel(){
                 return this.panelLabelConfig('left');

--- a/src/styles/components/date-picker.less
+++ b/src/styles/components/date-picker.less
@@ -205,7 +205,7 @@
 
     &-with-week-numbers{
         .@{picker-prefix-cls}-panel{
-            &-body{
+            &-body-date {
                 min-width: (@date-picker-cells-width-with-weeknumbers + 20) * 2;
             }
         }


### PR DESCRIPTION
Correct panel width when showing week numbers.

Demo: https://jsfiddle.net/4d2Ljf64/

Image of the problem:

![skarmavbild 2018-05-16 kl 10 08 36](https://user-images.githubusercontent.com/5614559/40104632-242c1386-58f1-11e8-8d92-e7b72f4f4c04.png)

