### PR TITLE
Use visibility instead of display

### DIFF
--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -146,7 +146,7 @@
             },
             barStyle () {
                 let style = {
-                    display: 'none',
+                    visibility: 'hidden',
                     width: `${this.barWidth}px`
                 };
                 if (this.type === 'line') style.display = 'block';
@@ -388,14 +388,10 @@
                 const nextIndex = Math.max(this.navList.findIndex(tab => tab.name === this.focusedKey), 0);
                 [...this.$refs.panes.children].forEach((el, i) => {
                     if (nextIndex === i) {
-                        [...el.children].forEach(child => child.style.display = 'block');
-                        setTimeout(() => {
-                            focusFirst(el, el);
-                        }, transitionTime);
+                        [...el.children].forEach(child => child.style.visibility = 'visible');
+                        setTimeout(() => focusFirst(el, el), transitionTime);
                     } else {
-                        setTimeout(() => {
-                            [...el.children].forEach(child => child.style.display = 'none');
-                        }, transitionTime);
+                        [...el.children].forEach(child => child.style.visibility = 'hidden');
                     }
                 });
             }

--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -149,7 +149,7 @@
                     visibility: 'hidden',
                     width: `${this.barWidth}px`
                 };
-                if (this.type === 'line') style.display = 'block';
+                if (this.type === 'line') style.visibility = 'visible';
                 if (this.animated) {
                     style.transform = `translate3d(${this.barOffset}px, 0px, 0px)`;
                 } else {


### PR DESCRIPTION
Using `display: none;` created some unexpected problems and actually `visibility` does the same effect of preventing elements to be focusable, which is better than the first solution. 
I should have came up with this version from the beginning.