### PR TITLE
Use label first if available

### DIFF
--- a/src/components/select/option.vue
+++ b/src/components/select/option.vue
@@ -58,7 +58,7 @@
                 return (this.label) ? this.label : this.value;
             },
             optionLabel(){
-                return (this.$el && this.$el.textContent) || this.label;
+                return this.label || (this.$el && this.$el.textContent);
             }
         },
         methods: {

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -129,9 +129,10 @@
     };
 
     const getOptionLabel = option => {
+        if (option.componentOptions.propsData.label) return option.componentOptions.propsData.label;
         const textContent = (option.componentOptions.children || []).reduce((str, child) => str + (child.text || ''), '');
         const innerHTML = getNestedProperty(option, 'data.domProps.innerHTML');
-        return option.componentOptions.propsData.label || textContent || (typeof innerHTML === 'string' ? innerHTML : '');
+        return textContent || (typeof innerHTML === 'string' ? innerHTML : '');
     };
 
 


### PR DESCRIPTION
Use `option.label` first and only `textContent` as a fallback