### PR TITLE
Fix 3732 - add prop for capturing focus

### DIFF
--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -84,6 +84,10 @@
                 type: Boolean,
                 default: true
             },
+            captureFocus: {
+                type: Boolean,
+                default: false
+            },
             closable: {
                 type: Boolean,
                 default: false
@@ -376,7 +380,7 @@
                 [...this.$refs.panes.children].forEach((el, i) => {
                     if (index === i) {
                         [...el.children].forEach(child => child.style.visibility = 'visible');
-                        setTimeout(() => focusFirst(el, el), transitionTime);
+                        if (this.captureFocus) setTimeout(() => focusFirst(el, el), transitionTime);
                     } else {
                         setTimeout(() => {
                             [...el.children].forEach(child => child.style.visibility = 'hidden');


### PR DESCRIPTION
This PR is a fix for #3732. The possibility to do TAB navigation added new challenges and we need to have control of the `focused` element. Since this is a breaking change we could have a prop for it called `:capture-focus` that defaults to `false` to keep the old behaviour. We can discuss later how the behaviour should be in 3.0.