### PR TITLE
Datepicker patches

### DIFF
--- a/src/components/date-picker/panel/Date/date-range.vue
+++ b/src/components/date-picker/panel/Date/date-range.vue
@@ -161,7 +161,7 @@
                 leftPickerTable: `${this.selectionMode}-table`,
                 rightPickerTable: `${this.selectionMode}-table`,
                 leftPanelDate: leftPanelDate,
-                rightPanelDate: new Date(leftPanelDate.getFullYear(), leftPanelDate.getMonth() + 1, leftPanelDate.getDate())
+                rightPanelDate: new Date(leftPanelDate.getFullYear(), leftPanelDate.getMonth() + 1, 1)
             };
         },
         computed: {

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -668,7 +668,7 @@
                 this.reset();
             },
             focus() {
-                this.$refs.input.focus();
+                this.$refs.input && this.$refs.input.focus();
             }
         },
         watch: {


### PR DESCRIPTION

 - Use first day of month to avoid getting higher numbers than the month has. Fixes #3773
 - Focus only if component has input. Fixes #3769