### PR TITLE
Use label as query

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -423,10 +423,13 @@
                 };
             },
             getInitialValue(){
-                const {multiple, value} = this;
+                const {multiple, remote, value} = this;
                 let initialValue = Array.isArray(value) ? value : [value];
                 if (!multiple && (typeof initialValue[0] === 'undefined' || (String(initialValue[0]).trim() === '' && !Number.isFinite(initialValue[0])))) initialValue = [];
-                if (this.remote && !this.multiple && this.value) this.query = value;
+                if (remote && !multiple && value) {
+                    const data = this.getOptionData(value);
+                    this.query = data ? data.label : String(value);
+                }
                 return initialValue.filter((item) => {
                     return Boolean(item) || item === 0;
                 });


### PR DESCRIPTION
When selecting remote options the query is set to the value and not the label. It should be set to the label and fallback to value.

Fixes: #3872