### PR TITLE
fix: #3906

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -344,7 +344,8 @@
                     const selectedSlotOption = autoCompleteOptions[currentIndex];
 
                     return slotOptions.map(node => {
-                        if (node === selectedSlotOption || getNestedProperty(node, 'componentOptions.propsData.value') === this.value) return applyProp(node, 'isFocused', true);
+                        if (typeof node.tag === "undefined") return node;
+                        else if (node === selectedSlotOption || getNestedProperty(node, 'componentOptions.propsData.value') === this.value) return applyProp(node, 'isFocused', true);
                         return copyChildren(node, (child) => {
                             if (child !== selectedSlotOption) return child;
                             return applyProp(child, 'isFocused', true);


### PR DESCRIPTION
修复此 [issue](https://github.com/iview/iview/issues/3906) 中提到的，在 2.14.0 版本中，
设置 `AutoComplete` 值为 `null` 时，报 `TypeError: Cannot read property 'propsData' of undefined` 的问题。


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
