### PR TITLE
fix(slider): click slider bar get wrong action when max is beyond 100

### DIFF
--- a/src/components/slider/slider.vue
+++ b/src/components/slider/slider.vue
@@ -372,9 +372,10 @@
                 const currentX = this.getPointerX(event);
                 const sliderOffsetLeft = this.$refs.slider.getBoundingClientRect().left;
                 let newPos = ((currentX - sliderOffsetLeft) / this.sliderWidth * this.valueRange) + this.min;
+                let regularNewPos = newPos / this.valueRange * 100 ;
 
-                if (!this.range || newPos <= this.minPosition) this.changeButtonPosition(newPos, 'min');
-                else if (newPos >= this.maxPosition) this.changeButtonPosition(newPos, 'max');
+                if (!this.range || regularNewPos <= this.minPosition) this.changeButtonPosition(newPos, 'min');
+                else if (regularNewPos >= this.maxPosition) this.changeButtonPosition(newPos, 'max');
                 else this.changeButtonPosition(newPos, ((newPos - this.firstPosition) <= (this.secondPosition - newPos)) ? 'min' : 'max');
             },
 


### PR DESCRIPTION
the newPos compared with minPosition should be Regularized.

eg: [https://jsfiddle.net/6yhxfkn3/3/](https://jsfiddle.net/6yhxfkn3/3/) , click the left side of the min point.


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
