### PR TITLE
[Fix Bug]Fix auto-complete component's style problem

### DIFF
--- a/src/styles/components/auto-complete.less
+++ b/src/styles/components/auto-complete.less
@@ -13,6 +13,6 @@
         display: inline-block;
     }
     &.@{select-dropdown-prefix-cls} {
-        max-height: none;
+        max-height: 200px;
     }
 }


### PR DESCRIPTION
[#4126](https://github.com/iview/iview/issues/4126)

view the code, select-dropdown haven't set max-height value, i think it is required,so set value  '200px' which is same with select component's max-height value.