### PR TITLE
Add event 'on-row-context-menu' for Table component.

### DIFF
--- a/examples/routers/table.vue
+++ b/examples/routers/table.vue
@@ -1,7 +1,16 @@
 <template>
     <div>
-        <Table ref="currentRowTable" :columns="columns3" :data="data1"></Table>
+        <Table ref="currentRowTable" :columns="columns3" :data="data1" @on-row-contextmenu="onRowContextMenu"></Table>
         <Button @click="handleClearCurrentRow">Clear</Button>
+        <p v-if="contextMenuEvent">
+            Context Menu Event:<br>
+            &nbsp;&nbsp;x:{{contextMenuEvent.x}}, y: {{contextMenuEvent.y}}<br>
+            &nbsp;&nbsp;pageX: {{contextMenuEvent.pageX}}, pageY: {{contextMenuEvent.pageY}} <br>
+            &nbsp;&nbsp;clientX:{{contextMenuEvent.clientX}}, clientY: {{contextMenuEvent.clientY}}<br>
+            &nbsp;&nbsp;screenX:{{contextMenuEvent.screenX}}, screenY: {{contextMenuEvent.screenY}}<br>
+            &nbsp;&nbsp;offsetX:{{contextMenuEvent.offsetX}}, offsetY: {{contextMenuEvent.offsetY}}<br>
+            &nbsp;&nbsp;layerX:{{contextMenuEvent.layerX}}, layerY: {{contextMenuEvent.layerY}}<br>
+        </p>
     </div>
 </template>
 <script>
@@ -56,12 +65,17 @@
                         address: 'Ottawa No. 2 Lake Park',
                         date: '2016-10-04'
                     }
-                ]
+                ],
+                contextMenuEvent: null
             }
         },
         methods: {
             handleClearCurrentRow () {
                 this.$refs.currentRowTable.clearCurrentRow();
+                this.contextMenuEvent = null;
+            },
+            onRowContextMenu (row, index, event) {
+                this.contextMenuEvent = event;
             }
         }
     }

--- a/examples/routers/table.vue
+++ b/examples/routers/table.vue
@@ -1,15 +1,9 @@
 <template>
     <div>
-        <Table ref="currentRowTable" :columns="columns3" :data="data1" @on-row-contextmenu="onRowContextMenu"></Table>
+        <Table ref="currentRowTable" :columns="columns3" :data="data1" :context-menu="contextMenu"></Table>
         <Button @click="handleClearCurrentRow">Clear</Button>
         <p v-if="contextMenuEvent">
-            Context Menu Event:<br>
-            &nbsp;&nbsp;x:{{contextMenuEvent.x}}, y: {{contextMenuEvent.y}}<br>
-            &nbsp;&nbsp;pageX: {{contextMenuEvent.pageX}}, pageY: {{contextMenuEvent.pageY}} <br>
-            &nbsp;&nbsp;clientX:{{contextMenuEvent.clientX}}, clientY: {{contextMenuEvent.clientY}}<br>
-            &nbsp;&nbsp;screenX:{{contextMenuEvent.screenX}}, screenY: {{contextMenuEvent.screenY}}<br>
-            &nbsp;&nbsp;offsetX:{{contextMenuEvent.offsetX}}, offsetY: {{contextMenuEvent.offsetY}}<br>
-            &nbsp;&nbsp;layerX:{{contextMenuEvent.layerX}}, layerY: {{contextMenuEvent.layerY}}<br>
+            Context Menu Event: {{contextMenuEvent}}
         </p>
     </div>
 </template>
@@ -73,9 +67,22 @@
             handleClearCurrentRow () {
                 this.$refs.currentRowTable.clearCurrentRow();
                 this.contextMenuEvent = null;
-            },
-            onRowContextMenu (row, index, event) {
-                this.contextMenuEvent = event;
+            }
+        },
+        computed: {
+            contextMenu () {
+                return {
+                    render (h, {row, index}) {
+                        return h('DropdownMenu', [
+                            h('DropdownItem', {props: {name: `${index} - Some Title`}}, 'Some Title'),
+                            h('DropdownItem', {props: {name: `${index} - Yo, ${row.name}`}}, `Yo, ${row.name}`),
+                            h('DropdownItem', {props: {name: `${index} - Yo, No.${index}`}}, `Yo, No.${index}`)
+                        ]);
+                    },
+                    onClick: (name) => {
+                        this.contextMenuEvent = name;
+                    }
+                };
             }
         }
     }

--- a/src/components/table/context-menu.js
+++ b/src/components/table/context-menu.js
@@ -1,0 +1,17 @@
+export default {
+    // For catch DropdownItem 'on-click' event.
+    //  see: @/components/dropdown/dropdown-item.vue:39
+    name: 'Dropdown',
+    props: {
+        row: Object,
+        render: Function,
+        index: Number
+    },
+    render (h) {
+        const params = {
+            row: this.row,
+            index: this.index
+        };
+        return this.render(h, params);
+    }
+};

--- a/src/components/table/table-body.vue
+++ b/src/components/table/table-body.vue
@@ -12,7 +12,8 @@
                     @mouseenter.native.stop="handleMouseIn(row._index)"
                     @mouseleave.native.stop="handleMouseOut(row._index)"
                     @click.native="clickCurrentRow(row._index)"
-                    @dblclick.native.stop="dblclickCurrentRow(row._index)">
+                    @dblclick.native.stop="dblclickCurrentRow(row._index)"
+                    @contextmenu.native="contextmenuCurrentRow(row._index, $event)">
                     <td v-for="column in columns" :class="alignCls(column, row)">
                         <Cell
                             :fixed="fixed"
@@ -95,6 +96,9 @@
             },
             dblclickCurrentRow (_index) {
                 this.$parent.dblclickCurrentRow(_index);
+            },
+            contextmenuCurrentRow (_index, event) {
+                this.$parent.contextmenuCurrentRow(_index, event);
             }
         }
     };

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -493,6 +493,13 @@
                 this.highlightCurrentRow (_index);
                 this.$emit('on-row-dblclick', JSON.parse(JSON.stringify(this.cloneData[_index])), _index);
             },
+            contextmenuCurrentRow (_index, rawEvent) {
+                this.highlightCurrentRow(_index);
+                this.$emit('on-row-contextmenu', this.cloneData[_index], _index, rawEvent);
+                if ('on-row-contextmenu' in this.$listeners) {
+                    rawEvent.preventDefault();
+                }
+            },
             getSelection () {
                 let selectionIndexes = [];
                 for (let i in this.objData) {

--- a/src/styles/components/table.less
+++ b/src/styles/components/table.less
@@ -8,6 +8,10 @@
         border-bottom: 0;
         border-right: 0;
     }
+
+    &-context-menu {
+        position: fixed;
+    }
     width: inherit;
     height: 100%;
     max-width: 100%;


### PR DESCRIPTION
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
Features:
- When there is no 'on-row-contextmenu' listener, default context menu(depends on browser) will show up.
- The 'on-row-contextmenu' event carries three payloads: row, index and original mouse event.

Why:
- We can take context menu as an operation menu for row data, which save one colume from
 rendering rapid operation button group for several times. The bast practice is, use one
 dropdown component containing operation list, when user right-click somewhere on table
 and the dropdown shows up on the clicked point, and this is why we need the third param.

功能：
- 当没有监听'on-row-contextmenu'时会显示浏览器默认的context menu
- 'on-contextmenu'事件携带三个参数：row、index和原生的event

为什么要增加这个功能
- 我们可以把context menu当做一行数据的操作菜单，以此来节省一列重复的操作按钮的渲染。最好的方式是，用户右键点击某一列数据时，一个Dropdown组件会显示在鼠标点击的位置（使用原生的鼠标事件确定位置）

-----

commit [d2c9681]:

Features: 
- Provides a default context menu using dropdown component.

Usage:
- Add contextMenu props to table or row data: `{render: Function, onClick: Function}`.
- Use iView's DropdownMenu and DropdownItem components.
- See examples/routers/table.vue

功能：
- 提供了一个使用下拉菜单的默认context menu

用法：
- 给Table组件添加contextMenu props或给行数据添加contextMenu，格式为：{render: Function, onClick: Function}
- 只可以使用iView的DropdownMenu和DropdownItem组件
- 在examples/routers/table.vue文件中可以找到例子
