### PR TITLE
Parse dates to be sure we consume correct format

### DIFF
--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -646,6 +646,7 @@
                 }
             },
             onPick(dates, visible = false, type) {
+                dates = this.parseDate(dates);
                 if (this.multiple){
                     const pickedTimeStamp = dates.getTime();
                     const indexOfPickedDate = this.internalValue.findIndex(date => date && date.getTime() === pickedTimeStamp);


### PR DESCRIPTION
When we use shortcut function and return a date string the `onPick` method will complain since it expects Date objects. Running `.parse` on the passed arguments normalises this.

Fixes #4127