### PR TITLE
Correct month last day when changing date panel dates

### DIFF
--- a/src/components/date-picker/panel/Date/date-range.vue
+++ b/src/components/date-picker/panel/Date/date-range.vue
@@ -260,8 +260,8 @@
             },
             setPanelDates(leftPanelDate){
                 this.leftPanelDate = leftPanelDate;
-                const rightPanelDate = new Date(leftPanelDate.getFullYear(), leftPanelDate.getMonth() + 1, leftPanelDate.getDate());
-                this.rightPanelDate = this.splitPanels ? new Date(Math.max(this.dates[1], rightPanelDate)) : rightPanelDate;
+                const rightPanelDate = new Date(leftPanelDate.getFullYear(), leftPanelDate.getMonth() + 1, 1);
+                this.rightPanelDate = this.splitPanels ? new Date(Math.max(this.dates[1].getTime(), rightPanelDate.getTime())) : rightPanelDate;
             },
             panelLabelConfig (direction) {
                 const locale = this.t('i.locale');

--- a/src/components/date-picker/panel/Date/date-range.vue
+++ b/src/components/date-picker/panel/Date/date-range.vue
@@ -312,9 +312,18 @@
                 } else {
                     // keep the panels together
                     const otherPanel = panel === 'left' ? 'right' : 'left';
-                    const otherCurrent = new Date(this[`${otherPanel}PanelDate`]);
-                    otherCurrent[`set${type}`](otherCurrent[`get${type}`]() + increment);
-                    this[`${otherPanel}PanelDate`] = otherCurrent;
+                    const currentDate = this[`${otherPanel}PanelDate`];
+                    const temp = new Date(currentDate);
+
+                    if (type === 'Month') {
+                        const nextMonthLastDate = new Date(
+                            temp.getFullYear(), temp.getMonth() + increment + 1, 0
+                        ).getDate();
+                        temp.setDate(Math.min(nextMonthLastDate, temp.getDate()));
+                    }
+
+                    temp[`set${type}`](temp[`get${type}`]() + increment);
+                    this[`${otherPanel}PanelDate`] = temp;
                 }
             },
             showYearPicker (panel) {


### PR DESCRIPTION
Correct date navigation when starting from the last day of a month that has more days than the next chosen month.

Fixes #3773 