### PR TITLE
fix form-item label-width bug

### DIFF
--- a/src/components/form/form-item.vue
+++ b/src/components/form/form-item.vue
@@ -127,8 +127,9 @@
             },
             labelStyles () {
                 let style = {};
-                const labelWidth = this.labelWidth || this.form.labelWidth;
-                if (labelWidth) {
+                let labelWidth
+                this.labelWidth === 0 || this.labelWidth ? labelWidth = this.labelWidth : labelWidth = this.form.labelWidth
+                if (labelWidth || labelWidth === 0) {
                     style.width = `${labelWidth}px`;
                 }
                 return style;


### PR DESCRIPTION
当设置了 Form 的 label-width 为 80 且设置 Form-Item 的值为 0 时，Form-Item 的 label-width 值被 Form 的 label-width 值覆盖了。

When set Form's label-width value is to 80 and the Form-Item's  is set to 0, the Form-Item's label-width value is overridden by the Form's label-width value.


<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
