### PR TITLE
树控件新增on-check和on-select事件用来返回被修改状态的node

### DIFF
--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -375,11 +375,11 @@
             updateVisibility(index){
                 [...this.$refs.panes.children].forEach((el, i) => {
                     if (index === i) {
-                        [...el.children].forEach(child => child.style.visibility = 'visible');
+                        [...el.children].filter(child=> child.classList.contains(`${prefixCls}-tabpane`)).forEach(child => child.style.visibility = 'visible');
                         setTimeout(() => focusFirst(el, el), transitionTime);
                     } else {
                         setTimeout(() => {
-                            [...el.children].forEach(child => child.style.visibility = 'hidden');
+                            [...el.children].filter(child=> child.classList.contains(`${prefixCls}-tabpane`)).forEach(child => child.style.visibility = 'hidden');
                         }, transitionTime);
                     }
                 });

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -160,6 +160,7 @@
                 this.$set(node, 'selected', !node.selected);
 
                 this.$emit('on-select-change', this.getSelectedNodes());
+                this.$emit('on-select', node);// give the changed node to user
             },
             handleCheck({ checked, nodeKey }) {
                 const node = this.flatState[nodeKey].node;
@@ -168,8 +169,9 @@
 
                 this.updateTreeUp(nodeKey); // propagate up
                 this.updateTreeDown(node, {checked, indeterminate: false}); // reset `indeterminate` when going down
-
+                
                 this.$emit('on-check-change', this.getCheckedNodes());
+                this.$emit('on-check', node);// give the changed node to user
             }
         },
         created(){


### PR DESCRIPTION
### why I pull this request
when we using iview's tree to **select/check**  any node, we just can get all selected/checked nodes by **on-select/check-change** event. But we usually want to get changed node from those events,and we can use `tree.getCheckedNodes/getSelectedNodes`to get all  selected/checked nodes.We need's use on-select-change to get it ******twice!******
### how to resolve it
    I add on-check/on-select in tree's handleSelect/hanleCheck function to get node.
```javascript
this.$emit('on-check', node);// give the changed node to user
this.$emit('on-select', node);// give the changed node to user
```
### 提这个变更项的原因
当我们在使用iview的树控件的时候，我们只可以通过on-select/check-change事件，获得到所有selected/checked nodes 。但是我们已经可以通过getCheckedNodes/getSelectedNodes获取到这些节点了，但是我们却无法轻易的通过on-check-change事件获得本次被选中的节点，因为handleCheck方法中还处理了级联状态的节点，所以我们不能从两次事件的节点中不同的节点来获得本次点击的节点。
```javascript
this.updateTreeUp(nodeKey); // propagate up
this.updateTreeDown(node, {checked, indeterminate: false}); // reset `indeterminate` when going down
```
这就和on-check-change事件本身该做的事情背离了，通过这个方法得不到操作的node

###解决方法
在`handleSelect/hanleCheck`方法中分别添加了
```javascript
this.$emit('on-check', node);// give the changed node to user
this.$emit('on-select', node);// give the changed node to user
```
** 最好的方法是直接修改on-check-change返回值，但是因为考虑这将会影响更新版本的用户之前的代码。之后我会提交一版直接修改on-check-change返回值的版本。作者大大看看merge哪个吧，如果是后面这版别忘了把官网的API修改一下**