### PR TITLE
直接修改tree  on-select-change/ on-check-change 返回值  为  node

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -250,7 +250,7 @@
                         this.close();
                     }
                 }
-                e.stopPropagation();
+                e.stopPropagation();//add stopPropagation
             },
             animationFinish() {
                 this.$emit('on-hidden');

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -250,6 +250,7 @@
                         this.close();
                     }
                 }
+                e.stopPropagation();
             },
             animationFinish() {
                 this.$emit('on-hidden');

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -159,7 +159,7 @@
                 }
                 this.$set(node, 'selected', !node.selected);
 
-                this.$emit('on-select-change', this.getSelectedNodes());
+                this.$emit('on-select-change', node);
             },
             handleCheck({ checked, nodeKey }) {
                 const node = this.flatState[nodeKey].node;
@@ -169,7 +169,7 @@
                 this.updateTreeUp(nodeKey); // propagate up
                 this.updateTreeDown(node, {checked, indeterminate: false}); // reset `indeterminate` when going down
 
-                this.$emit('on-check-change', this.getCheckedNodes());
+                this.$emit('on-check-change', node);
             }
         },
         created(){


### PR DESCRIPTION
### why I pull this request
when we using iview's tree to **select/check**  any node, we just can get all selected/checked nodes by **on-select/check-change** event. But we usually want to get changed node from those events,and we can use `tree.getCheckedNodes/getSelectedNodes`to get all  selected/checked nodes.We need's use on-select-change to get it ******twice!******
### how to resolve it
    I add on-check/on-select in tree's handleSelect/hanleCheck function to get node.
```javascript
this.$emit('on-check-change', node);// give the changed node to user
this.$emit('on-select-change', node);// give the changed node to user
```
### 提这个变更项的原因
当我们在使用iview的树控件的时候，我们只可以通过on-select/check-change事件，获得到所有selected/checked nodes 。但是我们已经可以通过getCheckedNodes/getSelectedNodes获取到这些节点了，但是我们却无法轻易的通过on-check-change事件获得本次被选中的节点，因为handleCheck方法中还处理了级联状态的节点，所以我们不能从两次事件的节点中不同的节点来获得本次点击的节点。
```javascript
this.updateTreeUp(nodeKey); // propagate up
this.updateTreeDown(node, {checked, indeterminate: false}); // reset `indeterminate` when going down
```
这就和on-check-change事件本身该做的事情背离了，通过这个方法得不到操作的node

###解决方法
在`handleSelect/hanleCheck`方法中分别添加了
```javascript
this.$emit('on-check-change', node);// give the changed node to user
this.$emit('on-select-change', node);// give the changed node to user
```

如果merge了这个版本（这是我想的最优解，因为之前的返回值是没什么卵用的，哈哈），官网的API记得改下！！
