### PR TITLE
去除cell的overflow:hidden属性

### DIFF
--- a/src/styles/components/table.less
+++ b/src/styles/components/table.less
@@ -145,7 +145,6 @@
     &-cell{
         padding-left: 18px;
         padding-right: 18px;
-        overflow: hidden;
         text-overflow: ellipsis;
         white-space: normal;
         word-break: break-all;


### PR DESCRIPTION
经过仔细的研究发现，如果设置了这个属性，那么table表格里面的第一个按钮的focus样式显示不全，只会显示左右阴影，而上下阴影则被hidden了，同样适用于ivu-btn-text
详见官方文档示例中，含有btn表格的第一个按钮，鼠标点击上去之后和第二个按钮的差别
https://www.iviewui.com/components/table

<!-- 目前仍然需要提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
