### PR TITLE
modal esc event stopPropagation

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -250,6 +250,7 @@
                         this.close();
                     }
                 }
+                e.stopPropagation();
             },
             animationFinish() {
                 this.$emit('on-hidden');


### PR DESCRIPTION
### Modal 在 EscClose 方法中添加 stopPropagation
在iview3.0中，Modal新增了draggable和mask，这使得**多Modal**的场景会增多
当有多个Modal的时候，视觉上会有层级关系。
当用户按下Esc的时候，通常用户习惯是想关闭最上层的Modal，但是现在是关闭全部Modal
所以我们需要
```javascript
e.stopPropagation();
```

