### PR TITLE
Fix select

### DIFF
--- a/src/components/select/functional-options.vue
+++ b/src/components/select/functional-options.vue
@@ -18,11 +18,17 @@
             },
         },
         functional: true,
-        render(h, {props, parent}){
-            // to detect changes in the $slot children/options we do this hack
-            // so we can trigger the parents computed properties and have everything reactive
-            // although $slot.default is not
-            if (props.slotOptions !== parent.$slots.default) props.slotUpdateHook();
+        render(h, {props, parent}) {
+            // In order to response data changes,i do this hack. #4372
+            if(props.slotOptions.length > 0) {
+                for(let i in props.slotOptions) {
+                    if(props.slotOptions[i].key !== parent.$slots.default[i].key) {
+                        props.slotUpdateHook();
+                        break;
+                    }
+                }
+            }
+            if(props.slotOptions && parent.$slots.default && props.slotOptions.length !== parent.$slots.default.length) props.slotUpdateHook();
             return props.options;
         }
     };

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -355,14 +355,12 @@
                         });
                     });
                 }
-                let hasDefaultSelected = slotOptions.some(option => this.query === option.key);
                 for (let option of slotOptions) {
 
                     const cOptions = option.componentOptions;
                     if (!cOptions) continue;
                     if (cOptions.tag.match(optionGroupRegexp)){
                         let children = cOptions.children;
-
                         // remove filtered children
                         if (this.filterable){
                             children = children.filter(
@@ -379,11 +377,8 @@
                         if (cOptions.children.length > 0) selectOptions.push({...option});
                     } else {
                         // ignore option if not passing filter
-                        if (!hasDefaultSelected) {
-                            const optionPassesFilter = this.filterable ? this.validateOption(cOptions) : option;
-                            if (!optionPassesFilter) continue;
-                        }
-
+                        const optionPassesFilter = this.filterable ? this.validateOption(cOptions) : option;
+                        if (!optionPassesFilter) continue;
                         optionCounter = optionCounter + 1;
                         selectOptions.push(this.processOption(option, selectedValues, optionCounter === currentIndex));
                     }

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -635,6 +635,9 @@
             },
             updateSlotOptions(){
                 this.slotOptions = this.$slots.default;
+                // #4372 issue, i find that this.query's value affects the judgment of the validateOption method.
+                this.query = '';
+                this.focusIndex = -1;
             },
             checkUpdateStatus() {
                 if (this.getInitialValue().length > 0 && this.selectOptions.length === 0) {


### PR DESCRIPTION
 functional-options.vue中render采用VNode的判断方法可能存在一些问题：在传入数组数据没变化的时候，props.slotOptions !== parent.$slots.default也存在为true的可能,而且会重复执行。

[#4273](https://github.com/iview/iview/issues/4273)
[#4372](https://github.com/iview/iview/issues/4372)

