### PR TITLE
Fix in #4317 Time component to internationalize

### DIFF
--- a/src/components/time/time.js
+++ b/src/components/time/time.js
@@ -47,7 +47,7 @@ const getDate = (timeStamp, startType) => {
  * @param {String|Number} timeStamp 时间戳
  * @returns {String} 相对时间字符串
  */
-export const getRelativeTime = timeStamp => {
+export const getRelativeTime = (timeStamp, locale) => {
     // 判断当前传入的时间戳是秒格式还是毫秒
     // const IS_MILLISECOND = true;
     // 如果是毫秒格式则转为秒格式
@@ -65,23 +65,23 @@ export const getRelativeTime = timeStamp => {
     // 如果IS_EARLY为false则差值取反
     if (!IS_EARLY) diff = -diff;
     let resStr = '';
-    const dirStr = IS_EARLY ? '前' : '后';
+    let dirStr = IS_EARLY ? (locale('i.time.before') || '前') : (locale('i.time.after') || '后');
 
-    if (diff < 1000) resStr = '刚刚';
+    if (diff < 1000) resStr = locale('i.time.just') || '刚刚';
     // 少于等于59秒
-    else if (diff < 60000) resStr = parseInt(diff / 1000) + '秒' + dirStr;
+    else if (diff < 60000) resStr = parseInt(diff / 1000) + (locale('i.time.seconds') || '秒') + dirStr;
     // 多于59秒，少于等于59分钟59秒
-    else if (diff >= 60000 && diff < 3600000) resStr = Math.floor(diff / 60000) + '分钟' + dirStr;
+    else if (diff >= 60000 && diff < 3600000) resStr = Math.floor(diff / 60000) + (locale('i.time.minutes') || '分钟') + dirStr;
     // 多于59分钟59秒，少于等于23小时59分钟59秒
-    else if (diff >= 3600000 && diff < 86400000) resStr = Math.floor(diff / 3600000) + '小时' + dirStr;
+    else if (diff >= 3600000 && diff < 86400000) resStr = Math.floor(diff / 3600000) + (locale('i.time.hours') || '小时') + dirStr;
     // 多于23小时59分钟59秒，少于等于29天59分钟59秒
-    else if (diff >= 86400000 && diff < 2623860000) resStr = Math.floor(diff / 86400000) + '天' + dirStr;
+    else if (diff >= 86400000 && diff < 2623860000) resStr = Math.floor(diff / 86400000) + (locale('i.time.days') || '天') + dirStr;
     // 多于29天59分钟59秒，少于364天23小时59分钟59秒，且传入的时间戳早于当前
     else if (diff >= 2623860000 && diff <= 31567860000 && IS_EARLY) resStr = getDate(timeStamp);
     else resStr = getDate(timeStamp, 'year');
     return resStr;
 };
 
-export default function (timestamp) {
-    return getRelativeTime(timestamp);
+export default function (timestamp, locale) {
+    return getRelativeTime(timestamp, locale);
 }

--- a/src/components/time/time.vue
+++ b/src/components/time/time.vue
@@ -5,12 +5,14 @@
     import Vue from 'vue';
     const isServer = Vue.prototype.$isServer;
     import { oneOf } from '../../utils/assist';
+    import Locale from '../../mixins/locale';
     import Time from './time';
 
     const prefixCls = 'ivu-time';
 
     export default {
         name: 'Time',
+        mixins: [Locale],
         props: {
             time: {
                 type: [Number, Date, String],
@@ -65,7 +67,7 @@
                 }
 
                 if (this.type === 'relative') {
-                    this.date = Time(time);
+                    this.date = Time(time, this.t);
                 } else {
                     const date = new Date(this.time);
                     const year = date.getFullYear();

--- a/src/locale/lang/en-US.js
+++ b/src/locale/lang/en-US.js
@@ -94,6 +94,15 @@ const lang = {
             star: 'Star',
             stars: 'Stars'
         },
+        time: {
+            before: ' ago',
+            after: ' after',
+            just: 'just now',
+            seconds: ' seconds',
+            minutes: ' minutes',
+            hours: ' hours',
+            days: ' days'
+        },
         tree: {
             emptyText: 'No Data'
         }

--- a/src/locale/lang/ja-JP.js
+++ b/src/locale/lang/ja-JP.js
@@ -94,6 +94,15 @@ const lang = {
             star: '点',
             stars: '点'
         },
+        time: {
+            before: '前',
+            after: '後',
+            just: 'たった今',
+            seconds: '秒',
+            minutes: '分',
+            hours: '時間',
+            days: '日'
+        },
         tree: {
             emptyText: 'データなし'
         }

--- a/src/locale/lang/zh-CN.js
+++ b/src/locale/lang/zh-CN.js
@@ -94,6 +94,15 @@ const lang = {
             star: '星',
             stars: '星'
         },
+        time: {
+            before: '前',
+            after: '后',
+            just: '刚刚',
+            seconds: '秒',
+            minutes: '分钟',
+            hours: '小时',
+            days: '天'
+        },
         tree: {
             emptyText: '暂无数据'
         }


### PR DESCRIPTION
<!-- 目前仍然需要提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

[Bug Report]Time controls do not translate internationally. #4317

Time Component is only in written in Chinese directly in js(src/components/time/time.js) file.
Then, I tried to set locale.
When you set 'time' property to locale file, Time compoment can be internationalized.

```
time: {
            before: ' ago',
            after: ' after',
            just: 'just now',
            seconds: ' seconds',
            minutes: ' minutes',
            hours: ' hours',
            days: ' days'
        },
```

...but, in Chinese `one seconds ago` is `1秒前`,  in English '1 seconds ago', There is a problem of space ...
I solved it to write ' seconds' (it includes one space) to setting file in English(/lang/en-US).
I think it is not best solution..., I would appriciate if you could give me to help with this problem.