### PR TITLE
fix select #4273

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -629,9 +629,9 @@
                     if (!this.autoComplete) this.$nextTick(() => inputField.focus());
                 }
                 this.broadcast('Drop', 'on-update-popper');
-                setTimeout(()=>{
+                setTimeout(() => {
                   this.filterQueryChange = false;
-                },500)
+                },300)
             },
             onQueryChange(query) {
                 if (query.length > 0 && query !== this.query) this.visible = true;


### PR DESCRIPTION
PR说明：

删除queryStringMatchesSelectedOption方法及其判断代码的原因是，这一段代码是为了在query值与上一个选中的值label完全匹配时直接显示全部选项。而之前使用这段代码，应该是为了在使用方向上下按键时可以在全部选项中移动，或者当选择某一个值得情况下放出所有选项。

现有的显示逻辑已经变化了，思路是：用户操作有且只有两种可能，一个是输入复制（query值改变），一个是选中（包含点击选中和键盘选中）。所以依据是否处于选中状态，来判断是否放开所有项；依据是否为输入状态时，来判断是否进行过滤判断。

所以之前的判断方式可能不适用于现在了。

这个PR通过了官网的demo检测，并且改善了细节问题，但可能检测demo有限，需要更多的测试情况来验证这个PR。