### PR TITLE
Table add on-select-all-cancel event

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -250,7 +250,7 @@
                         this.close();
                     }
                 }
-                e.stopPropagation();
+                e.stopPropagation();//add stopPropagation
             },
             animationFinish() {
                 this.$emit('on-hidden');

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -250,6 +250,7 @@
                         this.close();
                     }
                 }
+                e.stopPropagation();
             },
             animationFinish() {
                 this.$emit('on-hidden');

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -549,6 +549,8 @@
                 const selection = this.getSelection();
                 if (status) {
                     this.$emit('on-select-all', selection);
+                }else{
+                    this.$emit('on-select-all-cancel'); //on-select-all-cancel event
                 }
                 this.$emit('on-selection-change', selection);
             },

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -159,7 +159,7 @@
                 }
                 this.$set(node, 'selected', !node.selected);
 
-                this.$emit('on-select-change', this.getSelectedNodes());
+                this.$emit('on-select-change', node);
             },
             handleCheck({ checked, nodeKey }) {
                 const node = this.flatState[nodeKey].node;
@@ -169,7 +169,7 @@
                 this.updateTreeUp(nodeKey); // propagate up
                 this.updateTreeDown(node, {checked, indeterminate: false}); // reset `indeterminate` when going down
 
-                this.$emit('on-check-change', this.getCheckedNodes());
+                this.$emit('on-check-change', node);
             }
         },
         created(){


### PR DESCRIPTION
when we use table select, we also need an event to listen select cancel all.
so i add `on-select-all-cancel`  in table's `selectAll()` function to resolve it

```javascript
if (status) {
    this.$emit('on-select-all', selection);
}else{
    this.$emit('on-select-all-cancel'); //on-select-all-cancel event
}
```
