### PR TITLE
树控件增加一个方法getCheckedAndIndeterminateNodes可以获取到选中和不完全选中状态的节点组合

### DIFF
--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -141,6 +141,10 @@
                 /* public API */
                 return this.flatState.filter(obj => obj.node.checked).map(obj => obj.node);
             },
+            getCheckedAndIndeterminateNodes () {
+                /* public API */
+                return this.flatState.filter(obj => (obj.node.checked || obj.node.indeterminate)).map(obj => obj.node);
+            },
             updateTreeDown(node, changes = {}) {
                 for (let key in changes) {
                     this.$set(node, key, changes[key]);


### PR DESCRIPTION
树控件增加一个方法getCheckedAndIndeterminateNodes可以获取到选中和不完全选中状态的节点组合