### PR TITLE
fix(layout): fixed bug about has-sider class

### DIFF
--- a/src/components/layout/layout.vue
+++ b/src/components/layout/layout.vue
@@ -28,7 +28,7 @@
                 });
             }
         },
-        mounted () {
+        beforeCreate () {
             this.hasSider = this.findSider();
         }
     };


### PR DESCRIPTION
due to `${prefixCls}-has-sider` is added after parent component mounted, child **can not** get correct [getBoundingClientRect] in mounted life cycle.

<!-- 目前仍然需要提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
