### PR TITLE
transfer on-selected-change add selectValue

### DIFF
--- a/src/components/transfer/list.vue
+++ b/src/components/transfer/list.vue
@@ -111,7 +111,7 @@
                 if (item.disabled) return;
                 const index = this.checkedKeys.indexOf(item.key);
                 index > -1 ? this.checkedKeys.splice(index, 1) : this.checkedKeys.push(item.key);
-                this.$parent.handleCheckedKeys();
+                this.$parent.handleCheckedKeys(item);
             },
             updateFilteredData () {
                 this.showItems = this.data;

--- a/src/components/transfer/transfer.vue
+++ b/src/components/transfer/transfer.vue
@@ -138,6 +138,10 @@
             },
             notFoundText: {
                 type: String
+            },
+            keyInNode: {
+                type: Boolean,
+                default: true
             }
         },
         data () {
@@ -239,10 +243,11 @@
             handleRightCheckedKeysChange (keys) {
                 this.rightCheckedKeys = keys;
             },
-            handleCheckedKeys () {
+            handleCheckedKeys (selectNode) {
                 const sourceSelectedKeys = this.getValidKeys('left');
                 const targetSelectedKeys = this.getValidKeys('right');
-                this.$emit('on-selected-change', sourceSelectedKeys, targetSelectedKeys);
+                const selectValue = this.keyInNode ? selectNode : selectNode.key;
+                this.$emit('on-selected-change', sourceSelectedKeys, targetSelectedKeys, selectValue);
             }
         },
         watch: {


### PR DESCRIPTION
在不影响原有api使用下，新增了返回的selectValue参数，并且新增了props参数keyInNode，默认为true，则返回selectValue为当前选中或取消で项；若keyInNode为false，则返回selectValue为当前选中或取消で项的key。
![image](https://user-images.githubusercontent.com/35516482/48828574-0e4e4080-edab-11e8-9fba-648cae76a297.png)
