### PR TITLE
Fix CollapseTransition

### DIFF
--- a/src/components/base/collapse-transition.js
+++ b/src/components/base/collapse-transition.js
@@ -2,13 +2,20 @@
 
 import { addClass, removeClass } from '../../utils/assist';
 
+let isAfterLeave = true;
+
 const Transition = {
     beforeEnter(el) {
         addClass(el, 'collapse-transition');
         if (!el.dataset) el.dataset = {};
 
-        el.dataset.oldPaddingTop = el.style.paddingTop;
-        el.dataset.oldPaddingBottom = el.style.paddingBottom;
+        if (isAfterLeave) {
+          el.dataset.oldPaddingTop = el.style.paddingTop;
+          el.dataset.oldPaddingBottom = el.style.paddingBottom;
+        } else {
+          el.style.paddingTop = el.dataset.oldPaddingTop;
+          el.style.paddingBottom = el.dataset.oldPaddingBottom;
+        }
 
         el.style.height = '0';
         el.style.paddingTop = 0;
@@ -16,6 +23,7 @@ const Transition = {
     },
 
     enter(el) {
+        isAfterLeave = false;
         el.dataset.oldOverflow = el.style.overflow;
         if (el.scrollHeight !== 0) {
             el.style.height = el.scrollHeight + 'px';
@@ -63,6 +71,7 @@ const Transition = {
         el.style.overflow = el.dataset.oldOverflow;
         el.style.paddingTop = el.dataset.oldPaddingTop;
         el.style.paddingBottom = el.dataset.oldPaddingBottom;
+        isAfterLeave = true;
     }
 };
 


### PR DESCRIPTION
CollaspeTransition在触发leave钩子但未触发afterLeave钩子时打断重新触发beforeEnter钩子，而导致paddingTop,paddingBottom最终被设为0.
When the CollaspeTransition is  interrupted after the leave hook and before the afterLeave hook for re-trigger the beforeEnter hook,  paddingTop and paddingBottom would be set to 0 filnally.

<!-- 目前仍然需要提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
