### PR TITLE
feat: add alwaysExpand option to tree component

### DIFF
--- a/src/components/tree/node.vue
+++ b/src/components/tree/node.vue
@@ -2,7 +2,7 @@
     <collapse-transition>
         <ul :class="classes">
             <li>
-                <span :class="arrowClasses" @click="handleExpand">
+                <span v-if="!alwaysExpand" :class="arrowClasses" @click="handleExpand">
                     <Icon v-if="showArrow" type="ios-arrow-forward"></Icon>
                     <Icon v-if="showLoading" type="ios-loading" class="ivu-load-loop"></Icon>
                 </span>
@@ -22,6 +22,7 @@
                         :data="item"
                         :multiple="multiple"
                         :show-checkbox="showCheckbox"
+                        :always-expand="alwaysExpand"
                         :children-key="childrenKey">
                 </Tree-node>
             </li>
@@ -60,7 +61,11 @@
             showCheckbox: {
                 type: Boolean,
                 default: false
-            }
+            },
+            alwaysExpand: {
+                type: Boolean,
+                default: false
+            },
         },
         data () {
             return {

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -7,6 +7,7 @@
             visible
             :multiple="multiple"
             :show-checkbox="showCheckbox"
+            :always-expand="alwaysExpand"
             :children-key="childrenKey">
         </Tree-node>
         <div :class="[prefixCls + '-empty']" v-if="!stateTree.length">{{ localeEmptyText }}</div>
@@ -50,7 +51,11 @@
             },
             render: {
                 type: Function
-            }
+            },
+            alwaysExpand: {
+                type: Boolean,
+                default: false
+            },
         },
         data () {
             return {


### PR DESCRIPTION
child nodes are always expanded and hiding arrow icon when alwaysExpand option is true