### PR TITLE
Fix #5002: Cannot set a Slider with InputNumber value as 0 by using InputNumber

### DIFF
--- a/src/components/slider/slider.vue
+++ b/src/components/slider/slider.vue
@@ -379,7 +379,7 @@
             },
 
             handleInputChange (val) {
-                this.currentValue = [val || this.min, this.currentValue[1]];
+                this.currentValue = [val === 0 ? 0 : val || this.min, this.currentValue[1]];
                 this.emitChange();
             },
 


### PR DESCRIPTION
<!-- 目前仍然需要提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

Hello!

I found some specific Issue(#5002), and I found some solution so I opened pull request.

This bug occurs when `<Slider>` Component with `input-number` option, and if range of`:"min" :"max"` values are cover the value `0`.

Inside of `Slider.vue`, line 382 was look like this.

`this.currentValue = [val || this.min, this.currentValue[1]];` 

This condition cannot handle if I would like to set a value of `val` as Number `0`, because it considered as `false` so It fallback to `this.min`.

So by doing like below, we can handle case of Number `0`.

`this.currentValue = [val === 0 ? 0 : val || this.min, this.currentValue[1]];`

Thank you for read :)