### PR TITLE
修复#5153 Cascader不允许超出下拉图标显示文字

### DIFF
--- a/src/styles/components/cascader.less
+++ b/src/styles/components/cascader.less
@@ -19,6 +19,7 @@
     }
 
     .@{css-prefix}input{
+        padding-right: 24px;
         display: block;
         cursor: pointer;
     }


### PR DESCRIPTION
<!-- 目前仍然需要提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
