### PR TITLE
修改@link-color取值为@primary-color

### DIFF
--- a/src/styles/custom.less
+++ b/src/styles/custom.less
@@ -12,7 +12,7 @@
 @warning-color          : #ff9900;
 @error-color            : #ed4014;
 @normal-color           : #e6ebf1;
-@link-color             : #2D8cF0;
+@link-color             : @primary-color;
 @link-hover-color       : tint(@link-color, 20%);
 @link-active-color      : shade(@link-color, 5%);
 @selected-color         : fade(@primary-color, 90%);


### PR DESCRIPTION
修改src/styles/custom.less中`@link-color`的值为`@primary-color`，使link-color和link-hover-color与主题色保持一致