### PR TITLE
在 type 属性中加入原生 number 支持，去除 handleInput 中的 Number 类型检测

### DIFF
--- a/src/components/input/input.vue
+++ b/src/components/input/input.vue
@@ -85,7 +85,7 @@
         props: {
             type: {
                 validator (value) {
-                    return oneOf(value, ['text', 'textarea', 'password', 'url', 'email', 'date']);
+                    return oneOf(value, ['text', 'textarea', 'password', 'url', 'email', 'date', 'number']);
                 },
                 default: 'text'
             },
@@ -264,7 +264,7 @@
                 if (this.isOnComposition) return;
 
                 let value = event.target.value;
-                if (this.number && value !== '') value = Number.isNaN(Number(value)) ? value : Number(value);
+                //if (this.number && value !== '') value = Number.isNaN(Number(value)) ? value : Number(value);
                 this.$emit('input', value);
                 this.setCurrentValue(value);
                 this.$emit('on-change', event);


### PR DESCRIPTION
在 type 属性中加入原生 number 支持，去除 handleInput 中的 Number 类型检测，本身这个类型检测还是错的， Number.isNaN(Number(value)) ? value : Number(value);， 是 NaN 的时候（非数值）用原值？

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
