### PR TITLE
fixed post file with filename

### DIFF
--- a/src/components/upload/ajax.js
+++ b/src/components/upload/ajax.js
@@ -47,7 +47,7 @@ export default function upload(option) {
         });
     }
 
-    formData.append(option.filename, option.file);
+    formData.append(option.name, option.file, option.filename);
 
     xhr.onerror = function error(e) {
         option.onError(e);

--- a/src/components/upload/upload.vue
+++ b/src/components/upload/upload.vue
@@ -199,8 +199,9 @@
 
                 const before = this.beforeUpload(file);
                 if (before && before.then) {
+                    const supportPrototypes = ['[object File]', '[object Blob]'];
                     before.then(processedFile => {
-                        if (Object.prototype.toString.call(processedFile) === '[object File]') {
+                        if (supportPrototypes.indexOf(Object.prototype.toString.call(processedFile)) !== -1) {
                             this.post(processedFile);
                         } else {
                             this.post(file);
@@ -234,15 +235,14 @@
                 }
 
                 this.handleStart(file);
-                let formData = new FormData();
-                formData.append(this.name, file);
 
                 ajax({
                     headers: this.headers,
                     withCredentials: this.withCredentials,
                     file: file,
                     data: this.data,
-                    filename: this.name,
+                    name: this.name,
+                    filename: file.name,
                     action: this.action,
                     onProgress: e => {
                         this.handleProgress(e, file);


### PR DESCRIPTION
应用场景：
在上传图片之前，压缩图片后得到 Blob
在 Chrome 下可以将 Blob 转为 File，但是在 IE 下不支持 File()，所以只能传给 Upload 组件这个 Blob

原来的处理是，如果处理后的数据 prototype 是 File，那么就将处理后的数据上传，否则上传原 file
现在的更改，使处理后的数据如果使 Blob，也可以上传处理后的 Blob

eg:

```
    handleBeforeUpload (file) {
        // compress image
        return new Promise( resolve => {
          new Compressor(file, {
            success(result) {
              // IE does not support File(), resolve blob
              resolve(result)
            },
            error(err) {
              resolve(file)
            }
          })
        })
      }
```
