### PR TITLE
Fix #5289

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -683,7 +683,7 @@
 
                 if (value === '') this.values = [];
                 else if (checkValuesNotEqual(value,publicValue,values)) {
-                    this.$nextTick(() => this.values = getInitialValue().map(getOptionData).filter(Boolean));
+                    this.values = getInitialValue().map(getOptionData).filter(Boolean);
                     this.dispatch('FormItem', 'on-form-change', this.publicValue);
                 }
             },


### PR DESCRIPTION
Fix [5289]( https://github.com/iview/iview/issues/5289).
When using `$nextTick`, the watched values in `select` will emit input event with the original value(changed in itself mounted lifecycle), not the value that changed in father component.

