### PR TITLE
Updated Button's link processor logic

### DIFF
--- a/src/mixins/link.js
+++ b/src/mixins/link.js
@@ -15,12 +15,30 @@ export default {
                 return oneOf(value, ['_blank', '_self', '_parent', '_top']);
             },
             default: '_self'
-        }
+        },
+        append: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
     },
     computed: {
         linkUrl () {
             const type = typeof this.to;
-            return type === 'string' ? this.to : null;
+            if (type !== 'string') {
+                return null;
+            }
+            if (this.to.includes('//')) {
+                /* Absolute URL, we do not need to route this */
+                return this.to;
+            }
+            const router = this.$router;
+            if (router) {
+                const current = this.$route;
+                const route = router.resolve(this.to, current, this.append);
+                return route ? route.href : null;
+            }
+            return this.to;
         }
     },
     methods: {

--- a/src/mixins/link.js
+++ b/src/mixins/link.js
@@ -36,7 +36,7 @@ export default {
             if (router) {
                 const current = this.$route;
                 const route = router.resolve(this.to, current, this.append);
-                return route ? route.href : null;
+                return route ? route.href : this.to;
             }
             return this.to;
         }


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

At present the URLs are being used in the buttons are directly rendering the parameter passed to "to", however in cases where the app is deployed under subfolders we provide a base to the vue-router and that base should be prefixed to the routes. 

This behavior already exists in vue-router, but since the theme does not use vue-router to resolve the links the links are not rendered correctly.

In this PR I have updated the function used to render the link so that it works across a multitude of cases:

1. Absolute URLs i.e. ones with http or https that always must contain // are sent back as it is
2. URLs are sent back as it is in case there is no vue router available
3. Vue router is used to resolve the URLs, the code is copied over from the source code of vue router. If the vue router resolver returns a valid route then we use that, otherwise we return the original URL