### PR TITLE
Fix table performance

### DIFF
--- a/src/components/table/table-body.vue
+++ b/src/components/table/table-body.vue
@@ -8,7 +8,7 @@
                 <table-tr
                     :draggable="draggable"
                     :row="row"
-                    :key="row._rowKey"
+                    :key="index"
                     :prefix-cls="prefixCls"
                     @mouseenter.native.stop="handleMouseIn(row._index)"
                     @mouseleave.native.stop="handleMouseOut(row._index)"


### PR DESCRIPTION
This performance issue is caused by table's data manipulating.
Table replicates source data and always applies a new key to render
data, which causing re-render when table's source data changed.
Use index as key instead to prevent futher re-render, for now.

Closes #4099

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
