### PR TITLE
modal监听on-cancel事件 在esc close时触发，与cancel表现一致

### DIFF
--- a/src/components/modal/confirm.js
+++ b/src/components/modal/confirm.js
@@ -90,7 +90,8 @@ Modal.newInstance = properties => {
                 on: {
                     input: (status) => {
                         this.visible = status;
-                    }
+                    },
+                    'on-cancel': this.cancel
                 }
             }, [
                 h('div', {


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
重现地址 https://run.iviewui.com/7jdvpGZH
modal组件在esc-close时 confirm里没有监听到事件做处理