### PR TITLE
Select add icon props

### DIFF
--- a/examples/routers/select.vue
+++ b/examples/routers/select.vue
@@ -4,9 +4,11 @@
             size="small" style="width:auto; margin-right:100px"
             v-model="privacyKey"
             @on-change="onPrivacySelect"
-            :icon="privacy.icon"
-            placeholder=" ">
-            <Option v-for="(item,key) in privacyList" :value="item.value" :key="item.value">
+            :icon="privacy.icon">
+            <Option v-for="(item,key) in privacyList"
+                :value="item.value"
+                label=" "
+                :key="item.value">
                 <div slot>
                     <Icon :type="item.icon" />
                     <strong>{{ item.name }}</strong>
@@ -29,6 +31,8 @@
     export default {
         data () {
             return {
+                value: 2,
+                options: [{value: 1, label: 'Foo'}, {value: 2, label: 'Bar'}],
                 cityList: [
                     {
                         value: 'New York',

--- a/examples/routers/select.vue
+++ b/examples/routers/select.vue
@@ -1,5 +1,19 @@
 <template>
     <div style="margin: 200px;">
+        <Select
+            size="small" style="width:auto; margin-right:100px"
+            v-model="privacyKey"
+            @on-change="onPrivacySelect"
+            :icon="privacy.icon"
+            placeholder=" ">
+            <Option v-for="(item,key) in privacyList" :value="item.value" :key="item.value">
+                <div slot>
+                    <Icon :type="item.icon" />
+                    <strong>{{ item.name }}</strong>
+                    <p style="margin:5px 0 0 16px">{{item.desc}}</p>
+                </div>
+            </Option>
+        </Select>
         <Select size="small" v-model="model10" multiple style="width:260px">
             <Option v-for="item in cityList" :value="item.value" :key="item.value">{{ item.label }}</Option>
         </Select>
@@ -41,7 +55,37 @@
                         label: 'Canberra'
                     }
                 ],
-                model10: ['New York', 'London']
+                model10: ['New York', 'London'],
+                privacyList: {
+                    "public": {
+                        value:"public",
+                        name:"Public",
+                        desc:"Anyone on or off 'CompanyName'",
+                        icon:'md-globe'
+                    },
+                    "limited":{
+                        value:"limited",
+                        name:"Friends",
+                        desc:"Friends on 'CompanyName'",
+                        icon:'md-people'
+                    },
+                    "private":{
+                        value:"private",
+                        name:"Only me",
+                        desc:"Only me",
+                        icon:'md-lock'
+                    }
+                },
+                privacyKey: "public",
+                privacy:null
+            }
+        },
+        created() {
+            this.privacy = this.privacyList[this.privacyKey]
+        },
+        methods:{
+            onPrivacySelect(key) {
+                this.privacy = this.privacyList[key];
             }
         }
     }

--- a/src/components/select/select-head.vue
+++ b/src/components/select/select-head.vue
@@ -4,12 +4,7 @@
             <span class="ivu-tag-text">{{ item.label }}</span>
             <Icon type="ios-close" @click.native.stop="removeTag(item)"></Icon>
         </div>
-        <span
-            :class="singleDisplayClasses"
-            v-show="singleDisplayValue">
-            <Icon :type="icon" v-if="icon"/>
-            {{ singleDisplayValue }}
-            </span>
+        <span :class="singleDisplayClasses" v-show="singleDisplayValue"><Icon :type="icon" v-if="icon"/>{{ singleDisplayValue }}</span>
         <input
             :id="inputElementId"
             type="text"
@@ -204,9 +199,6 @@
             },
             queryProp(query){
                 if (query !== this.query) this.query = query;
-            },
-            icon() {
-                console.log(this.icon);
             }
         }
     };

--- a/src/components/select/select-head.vue
+++ b/src/components/select/select-head.vue
@@ -6,8 +6,10 @@
         </div>
         <span
             :class="singleDisplayClasses"
-            v-show="singleDisplayValue"
-        >{{ singleDisplayValue }}</span>
+            v-show="singleDisplayValue">
+            <Icon :type="icon" v-if="icon"/>
+            {{ singleDisplayValue }}
+            </span>
         <input
             :id="inputElementId"
             type="text"
@@ -77,7 +79,10 @@
             queryProp: {
                 type: String,
                 default: ''
-            }
+            },
+            icon: {
+                type: String
+            },
         },
         data () {
             return {
@@ -200,6 +205,9 @@
             queryProp(query){
                 if (query !== this.query) this.query = query;
             },
+            icon() {
+                console.log(this.icon);
+            }
         }
     };
 </script>

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -33,6 +33,7 @@
                     :multiple="multiple"
                     :values="values"
                     :clearable="canBeCleared"
+                    :icon="icon"
                     :disabled="disabled"
                     :remote="remote"
                     :input-element-id="elementId"
@@ -161,6 +162,10 @@
             label: {
                 type: [String, Number, Array],
                 default: ''
+            },
+            icon: {
+                type: String,
+                default:null
             },
             multiple: {
                 type: Boolean,


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
Hello, it would be really nice to add icon to `Select` like `Tab`
icon and selected value/placeholder.
```
<Select
    size="small" style="width:auto;"
    v-model="privacyKey"
    @on-change="onPrivacySelect"
    :icon="privacy.icon">
    <Option v-for="(item,key) in privacyList"
        :value="item.value"
        label=" "
        :key="item.value">
        <div slot>
            <Icon :type="item.icon" />
            <strong>{{ item.name }}</strong>
            <p style="margin:5px 0 0 16px">{{item.desc}}</p>
        </div>
    </Option>
</Select>

.......

methods:{
   onPrivacySelect(key) {
      this.privacy = this.privacyList[key];
   }
}
```
![Screen Shot 2019-03-21 at 4 23 44 PM](https://user-images.githubusercontent.com/33612405/54738064-020daf00-4bf6-11e9-8240-ce16a986fe57.png)
