### PR TITLE
修复notification的进入transition失效 & loading-bar新增duration属性

### DIFF
--- a/src/components/base/notification/notice.vue
+++ b/src/components/base/notification/notice.vue
@@ -1,5 +1,5 @@
 <template>
-    <transition :name="transitionName" @enter="handleEnter" @leave="handleLeave">
+    <transition :name="transitionName" @enter="handleEnter" @leave="handleLeave" appear>
         <div :class="classes" :style="styles">
             <template v-if="type === 'notice'">
                 <div :class="contentClasses" ref="content" v-html="content"></div>

--- a/src/components/loading-bar/index.js
+++ b/src/components/loading-bar/index.js
@@ -2,6 +2,7 @@ import LoadingBar from './loading-bar';
 
 let loadingBarInstance;
 let color = 'primary';
+let duration = 800;
 let failedColor = 'error';
 let height = 2;
 let timer;
@@ -32,7 +33,7 @@ function hide() {
                 percent: 0
             });
         }, 200);
-    }, 800);
+    }, duration);
 }
 
 function clearTimer() {
@@ -95,6 +96,9 @@ export default {
     config (options) {
         if (options.color) {
             color = options.color;
+        }
+        if (options.duration) {
+            duration = options.duration;
         }
         if (options.failedColor) {
             failedColor = options.failedColor;

--- a/types/loading-bar.d.ts
+++ b/types/loading-bar.d.ts
@@ -42,6 +42,11 @@ export declare interface LoadingBarConfig {
    */
   color?: string;
   /**
+   * 自动消失的延时, 默认为800ms
+   * @default 800
+   */
+  duration?: number;
+  /**
    * 失败时的进度条颜色，默认为 iView 主色 
    * @default error
    */


### PR DESCRIPTION
1. 修复Vue2.6.9版本更新导致的notification进入transition失效问题(失效原因是[4de4649](https://github.com/vuejs/vue/commit/4de4649d9637262a9b007720b59f80ac72a5620c))
2. 为loading-bar组件新增duration属性