### PR TITLE
feature: add stopPropagation for Dropdown

### DIFF
--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -57,6 +57,10 @@
             transferClassName: {
                 type: String
             },
+            stopPropagation: {
+                type: Boolean,
+                default: false
+            },
         },
         computed: {
             transition () {
@@ -164,6 +168,7 @@
         },
         mounted () {
             this.$on('on-click', (key) => {
+                if (this.stopPropagation) return;
                 const $parent = this.hasParent();
                 if ($parent) $parent.$emit('on-click', key);
             });


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
当Dropdown嵌套时，子菜单的点击事件会冒泡到父菜单。
但有时候需要子菜单处理自己的点击事件，而无需冒泡到父菜单。
该PR实现了这个功能
