### PR TITLE
fix input-number cursor style

### DIFF
--- a/src/styles/components/input-number.less
+++ b/src/styles/components/input-number.less
@@ -19,6 +19,7 @@
     border: 1px solid @border-color-base;
     border-radius: @btn-border-radius;
     overflow: hidden;
+    cursor: default;
 
     &-handler-wrap {
         width: 22px;


### PR DESCRIPTION
a chore cursor style problem in number input component: 

reproduce way: 

move mouse into number input from right (slowly), cursor style will change to 'text' when it cross border!(in a flash), then up to 'pointer' when it on handler element.

but the expect order is : ['default', 'pointer'], not ['default', 'text', 'pointer'].  Other input components is well. 