### PR TITLE
feature && fix #3646: checkbox中的on-change事件中增加第二个参数

### DIFF
--- a/examples/routers/checkbox.vue
+++ b/examples/routers/checkbox.vue
@@ -26,6 +26,8 @@
             <Checkbox v-for="item in tags" :label="item.label" :key="item.label" true-value="true"></Checkbox>
         </Checkbox-group>
         <div>{{ fruit }}</div>
+         <Checkbox v-model="testValue3" row="rowkey" @on-change="change">test on-change event</Checkbox>
+         <div>{{ testValue4 }}</div>    
     </div>
 </template>
 <script>
@@ -36,8 +38,15 @@
                 fruit: ['苹果'],
                 tags: [],
                 testValue1: null,
-                testValue2: null
+                testValue2: null,
+                testValue3: null,
+                testValue4: ''
             };
+        },
+        methods: {
+            change(val, row) {
+                this.testValue4 = String(val) + ' ' + String(row)
+            }
         },
         mounted () {
             setTimeout(() => {

--- a/src/components/checkbox/checkbox.vue
+++ b/src/components/checkbox/checkbox.vue
@@ -60,6 +60,9 @@
                 type: Boolean,
                 default: false
             },
+            row: {
+                type: [String, Number, Boolean],
+            },
             size: {
                 validator (value) {
                     return oneOf(value, ['small', 'large', 'default']);
@@ -144,7 +147,7 @@
                 if (this.group) {
                     this.parent.change(this.model);
                 } else {
-                    this.$emit('on-change', value);
+                    this.$emit('on-change', value, this.row);
                     this.dispatch('FormItem', 'on-form-change', value);
                 }
             },


### PR DESCRIPTION
对于checkbox的v-model绑定到复杂结构中一个值时，当值改变时想要获取这条数据中对应的某个值很困难，比如一个树形结构。实际用例链接
https://run.iviewui.com/kKQcSlyU
可以在on-change事件中增加第二个参数，该值由使用者通过prop传入。使使用者可以获取更详细的位置信息。
