### PR TITLE
feat(Input): remove prop :autocomplete value validation

### DIFF
--- a/src/components/input/input.vue
+++ b/src/components/input/input.vue
@@ -141,9 +141,7 @@
                 default: false
             },
             autocomplete: {
-                validator (value) {
-                    return oneOf(value, ['on', 'off']);
-                },
+                type: String,
                 default: 'off'
             },
             clearable: {


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

As a standard HTML5 attribute, [autocomplete has much more legal values other than `on` and `off`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete). What's more, `autocomplete="new-password"` is the only working way to disable autocomplete of password input field in modern browsers.

This PR simply removes the prop value check.