### PR TITLE
fix: 支持Modal的异步关闭在一些验证失败情景下能够关闭loading

### DIFF
--- a/src/components/modal/confirm.js
+++ b/src/components/modal/confirm.js
@@ -164,13 +164,15 @@ Modal.newInstance = properties => {
                 this.remove();
             },
             ok () {
-                if (this.loading) {
-                    this.buttonLoading = true;
-                } else {
-                    this.$children[0].visible = false;
-                    this.remove();
-                }
                 this.onOk();
+                this.$nextTick(() => {
+                    if (this.loading) {
+                        this.buttonLoading = true;
+                    } else {
+                        this.$children[0].visible = false;
+                        this.remove();
+                    }
+                });
             },
             remove () {
                 setTimeout(() => {

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -251,13 +251,15 @@
                 this.close();
             },
             ok () {
-                if (this.loading) {
-                    this.buttonLoading = true;
-                } else {
-                    this.visible = false;
-                    this.$emit('input', false);
-                }
                 this.$emit('on-ok');
+                this.$nextTick(() => {
+                    if (this.loading) {
+                        this.buttonLoading = true;
+                    } else {
+                        this.visible = false;
+                        this.$emit('input', false);
+                    }
+                });
             },
             EscClose (e) {
                 if (this.visible && this.closable) {


### PR DESCRIPTION
Modal的异步关闭能支持一些异步操作失败的情况：
  1. `on-ok`触发loading加载
  2. 如果一些异步操作失败，如表单验证失败等，取消loading
  3. 再次触发`on-ok`时仍可触发loading加载

```html
<Modal
    :loading="loading"
    @on-ok="ok"
/>
```

```js
ok() {
    this.loading = true
    // some asynchronous operations
    this.loading = false
}
```

目前的状态： https://run.iviewui.com/3z8d82mg