### PR TITLE
fix:修复清空搜索关键词后，重新搜索相同的关键词没有触发远程搜索

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -437,6 +437,8 @@
                 if (query === null) {
                     this.onQueryChange('');
                     this.values = [];
+                    //修复清空搜索关键词后，重新搜索相同的关键词没有触发远程搜索
+                    this.lastRemoteQuery='';
                 }
             },
             clearSingleSelect(){ // PUBLIC API

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -437,8 +437,8 @@
                 if (query === null) {
                     this.onQueryChange('');
                     this.values = [];
-                    //修复清空搜索关键词后，重新搜索相同的关键词没有触发远程搜索
-                    this.lastRemoteQuery='';
+                    // #5620,修复清空搜索关键词后，重新搜索相同的关键词没有触发远程搜索
+                    this.lastRemoteQuery = '';
                 }
             },
             clearSingleSelect(){ // PUBLIC API


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
### Environment
macOs / chrome 73 / iview 3.3.2

### Reproduction link
https://run.iviewui.com/preview/ild9YDc8

### Steps to reproduce
先任意一个单词(比如：s),然后点击'reset'按钮，接着重新搜索刚才的单词(s)，这个时候会发现没有匹配结果，调试发现是没有触发远程搜索。

### What is expected?
重新搜索相同的关键词可触发远程搜索。