### PR TITLE
fix picker focus style when disabled

### DIFF
--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -644,8 +644,8 @@
                 this.showClose = false;
             },
             handleIconClick (e) {
+                if (e) e.stopPropagation();
                 if (this.showClose) {
-                    if (e) e.stopPropagation();
                     this.handleClear();
                 } else if (!this.disabled) {
                     this.handleFocus();


### PR DESCRIPTION
reproduce demo: 

https://run.iviewui.com/2i3g3sC8

- click icon in disabled picker , focused style should not be active

