### PR TITLE
Delay check for vue-i18n 5.x

### DIFF
--- a/src/locale/index.js
+++ b/src/locale/index.js
@@ -8,8 +8,8 @@ let lang = defaultLang;
 let merged = false;
 let i18nHandler = function() {
     const vuei18n = Object.getPrototypeOf(this || Vue).$t;
-    if (typeof vuei18n === 'function' && !!Vue.locale) {
-        if (!merged) {
+    if (typeof vuei18n === 'function') {
+        if (!!Vue.locale && !merged) {
             merged = true;
             Vue.locale(
                 Vue.config.lang,


### PR DESCRIPTION
Vue.locale is only used for vue-i18n <= 5, it is not required to get a translation so as long as vuei18n is a function we should use it to get the corresponding translation.

