### PR TITLE
优化: checkbox 和 col , 调用父组件方法前先进行检查

### DIFF
--- a/src/components/checkbox/checkbox.vue
+++ b/src/components/checkbox/checkbox.vue
@@ -123,7 +123,7 @@
             }
 
             if (this.group) {
-                this.parent.updateModel(true);
+                this.parent.updateModel && this.parent.updateModel(true);
             } else {
                 this.updateModel();
                 this.showSlot = this.$slots.default !== undefined;

--- a/src/components/grid/col.vue
+++ b/src/components/grid/col.vue
@@ -74,7 +74,7 @@
         methods: {
             updateGutter () {
                 const Row = findComponentUpward(this, 'Row');
-                if (Row) {
+                if (Row && Row.updateGutter) {
                     Row.updateGutter(Row.gutter);
                 }
             }


### PR DESCRIPTION
对于 `Checkbox` , 如果用户把它放在自己定义的 `CheckboxGroup` 里，会在控制台报错。因为此时通过 `findComponentUpward` 找到的组件是用户自己定义的。这固然是用法的问题，但是 `CheckboxGroup` 依然是一个较为通用的组件名，也许这里做一下检查比较好。

详见：[jsbin.com/qobevel/edit?html,js,console,output](http://jsbin.com/qobevel/edit?html,js,console,output)

这个问题本质在于 `findComponentUpward` 只依靠组件名，不是一定能准确找到父组件，不知道之后是否有优化的计划？

此外，对代码中进行了检查，发现 `Row` 也有类似的问题，因此也处理了一下。另外 `caspanel` 组件中相似的逻辑已经被人处理过了。
