### PR TITLE
add  array  type to  form model

### DIFF
--- a/src/components/form/form.vue
+++ b/src/components/form/form.vue
@@ -10,7 +10,7 @@
         name: 'iForm',
         props: {
             model: {
-                type: Object
+                type: [ Object, Array ]
             },
             rules: {
                 type: Object


### PR DESCRIPTION
```
vue.runtime.esm.js?2b0e:619 [Vue warn]: Invalid prop: type check failed for prop "model". Expected Object, got Array 

found in

---> <IForm>

```
当表单绑定的model数据是数组时，报prop类型错误， 因为我这边一个表单里提交多个行数据的情况很常见
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
