### PR TITLE
modal-closeOnOk

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -20,7 +20,7 @@
                         <div :class="[prefixCls + '-footer']" v-if="!footerHide">
                             <slot name="footer">
                                 <i-button type="text" size="large" @click.native="cancel">{{ localeCancelText }}</i-button>
-                                <i-button type="primary" size="large" :loading="buttonLoading" @click.native="ok">{{ localeOkText }}</i-button>
+                                <i-button type="primary" size="large" :loading="buttonLoading" @click.native="ok" :disabled="disableOk">{{ localeOkText }}</i-button>
                             </slot>
                         </div>
                     </div>
@@ -127,6 +127,10 @@
             closeOnOk: {
                 type: Boolean,
                 default: true
+            },
+            disableOk: {
+                type: Boolean,
+                default: false
             },
         },
         data () {

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -124,6 +124,10 @@
                 type: Number,
                 default: 1000
             },
+            closeOnOk: {
+                type: Boolean,
+                default: true
+            },
         },
         data () {
             return {
@@ -253,7 +257,7 @@
             ok () {
                 if (this.loading) {
                     this.buttonLoading = true;
-                } else {
+                } else if(this.closeOnOk) {
                     this.visible = false;
                     this.$emit('input', false);
                 }


### PR DESCRIPTION
When I had to validation on my modal component after the 'OK' button, it was a bit complicated to keep it open for show warnings. Actually, for many cases, developers may want to manage modal visibility after `on-ok` method with `value` prop.


