### PR TITLE
Use filterMethod prop in Select component

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -494,15 +494,14 @@
                 const label = propsData.label || '';
                 const textContent = (elm && elm.textContent) || (children || []).reduce((str, node) => {
                     const nodeText = node.elm ? node.elm.textContent : node.text;
-                    return `${str} ${nodeText}`;
+                    return str === '' ? nodeText : `${str} ${nodeText}`;
                 }, '') || '';
 
                 if (this.filterMethod) {
                     return this.filterMethod(this.query, { value, label, textContent });
                 } else {
-                    const stringValues = JSON.stringify([value, label, textContent]);
                     const query = this.query.toLowerCase().trim();
-                    return stringValues.toLowerCase().includes(query);
+                    return [value, label, textContent].some((item) => item.toString().toLowerCase().includes(query));
                 }
             },
 

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -496,9 +496,14 @@
                     const nodeText = node.elm ? node.elm.textContent : node.text;
                     return `${str} ${nodeText}`;
                 }, '') || '';
-                const stringValues = JSON.stringify([value, label, textContent]);
-                const query = this.query.toLowerCase().trim();
-                return stringValues.toLowerCase().includes(query);
+
+                if (this.filterMethod) {
+                    return this.filterMethod(this.query, { value, label, textContent });
+                } else {
+                    const stringValues = JSON.stringify([value, label, textContent]);
+                    const query = this.query.toLowerCase().trim();
+                    return stringValues.toLowerCase().includes(query);
+                }
             },
 
             toggleMenu (e, force) {


### PR DESCRIPTION
I noticed that `filterMethod` prop was defined in `Select` component 3 years ago but was never used in this component.
And, I came across a demand that options should be filtered by label only.

This PR uses `filterMethod` prop in `validateOption` method, letting users be able to customize their own filter methods.

Related feature requests and bug reports:
Open:
#4192
#4013
#4951

Closed:
#3999
#5132
#5281

Related PR: #3663

Maybe @SergioCrisostomo is more familiar with this part.

I hope you would check this PR 😃 

Thank you.
