### PR TITLE
tooltip组件新增控制是否触发提示框显示的参数

### DIFF
--- a/src/components/tooltip/tooltip.vue
+++ b/src/components/tooltip/tooltip.vue
@@ -74,6 +74,10 @@
             },
             maxWidth: {
                 type: [String, Number]
+            },
+            canBeTriggered: {
+                type: Boolean,
+                default: true
             }
         },
         data () {
@@ -110,6 +114,7 @@
         },
         methods: {
             handleShowPopper() {
+                if(!this.canBeTriggered) return;
                 if (this.timeout) clearTimeout(this.timeout);
                 this.timeout = setTimeout(() => {
                     this.visible = true;


### PR DESCRIPTION
给 tooltip组件加上一个参数canBeTriggered，用于控制提示框在鼠标移入时是否显示出来（相当于给提示框加上v-show），可以在例如列表渲染等需要保持template结构统一的场景下使代码结构保持简洁。
