### PR TITLE
support call Message and Modal in ts file

### DIFF
--- a/types/message.d.ts
+++ b/types/message.d.ts
@@ -4,7 +4,9 @@
 // Definitions: https://github.com/yangdan8/iview.git
 import Vue, { VNode, CreateElement } from "vue";
 
-export declare class Message extends Vue {
+export const Message: MessageClass;
+
+export declare class MessageClass extends Vue {
     /**
      * 消息
      * @param config MessageConfig为相关配置,string为待显示的内容
@@ -77,6 +79,6 @@ declare module "vue/types/vue" {
         /**
          * 全局提示
          */
-        $Message: Message;
+        $Message: MessageClass;
     }
 }

--- a/types/modal.d.ts
+++ b/types/modal.d.ts
@@ -4,7 +4,9 @@
 // Definitions: https://github.com/yangdan8/iview.git
 import Vue, { VNode, CreateElement } from "vue";
 
-export declare class Modal extends Vue {
+export const Modal: ModalInstance;
+
+export declare class ModalClass extends Vue {
     /**
      * 对话框是否显示，可使用 v-model 双向绑定数据。
      * @default false
@@ -128,7 +130,7 @@ export declare class Modal extends Vue {
     };
 }
 
-export declare class ModalInstance extends Modal {
+export declare class ModalInstance extends ModalClass {
     /**
      * 消息
      * @param config ModalConfig为相关配置,string为待显示的内容


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

```js
    import { Message, Modal } from 'iview';

    Message.error('hello world');
    Modal.error('hello world');
```
At now, the types file only support call Message in vue component.
If you call Message from ts file, you will get error message `Property 'error' does not exist on type 'typeof Message'.`

The PR just fix the problem.



