### PR TITLE
取消checkbox和tag组件对值相关的props的类型限定

### DIFF
--- a/src/components/checkbox/checkbox.vue
+++ b/src/components/checkbox/checkbox.vue
@@ -42,15 +42,15 @@
                 default: false
             },
             value: {
-                type: [String, Number, Boolean],
+                // type: [String, Number, Boolean],
                 default: false
             },
             trueValue: {
-                type: [String, Number, Boolean],
+                // type: [String, Number, Boolean],
                 default: true
             },
             falseValue: {
-                type: [String, Number, Boolean],
+                // type: [String, Number, Boolean],
                 default: false
             },
             label: {

--- a/src/components/tag/tag.vue
+++ b/src/components/tag/tag.vue
@@ -45,7 +45,7 @@
                 }
             },
             name: {
-                type: [String, Number]
+                // type: [String, Number]
             },
             fade: {
                 type: Boolean,


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
Due to some requirements, we need to pass the value of the component Checkbox in type of Object,as same as the component Tag.
Although it is just a type check warning, I sincerely suggest that the development team can add an object type or just cancel type check on some "value-related properties" to prevent some similar issues.
基于某些需求，需要通过checkbox的value值传object；还有希望通过tag的点选状态来传object
我觉得类似的需求还有一些地方可能会做同样的改动。
虽然只是type check警告，建议开发团队可以添加object类型或者可以在某些“值相关的属性”上取消类型限定