### PR TITLE
为 table on-expand 事件添加 index 参数

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -566,7 +566,7 @@
                 }
                 const status = !data._isExpanded;
                 this.objData[_index]._isExpanded = status;
-                this.$emit('on-expand', JSON.parse(JSON.stringify(this.cloneData[_index])), status);
+                this.$emit('on-expand', JSON.parse(JSON.stringify(this.cloneData[_index])), status, _index);
                 
                 if(this.height || this.maxHeight){
                     this.$nextTick(()=>this.fixedBody());

--- a/types/table.d.ts
+++ b/types/table.d.ts
@@ -171,8 +171,9 @@ export declare class Table extends Vue {
      * 展开或收起某一行时触发
      * row：当前行的数据
      * status：当前的状态
+     * index：当前行索引
      */
-    $emit(eventName: "on-expand", row: object, status: string): this;
+    $emit(eventName: "on-expand", row: object, status: string, index: number): this;
     /**
      * 拖拽排序松开时触发，返回置换的两行数据索引
      * index1


### PR DESCRIPTION
在 `table` 的 `data` 改变后，`expand` 状态会被重置

但某些场景下需要保持 `table` 展开的状态

`on-expnad` 事件应该返回被展开/折叠的是哪行，以便于用户保存该行的 `expand` 状态