### PR TITLE
fix #5213

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -705,8 +705,10 @@
 
                 this.checkUpdateStatus();
 
+                const vModelValue = (publicValue && this.labelInValue) ?
+                    (this.multiple ? publicValue.map(({value}) => value) : publicValue.value) : publicValue;
                 if (value === '') this.values = [];
-                else if (checkValuesNotEqual(value,publicValue,values)) {
+                else if (checkValuesNotEqual(value,vModelValue,values)) {
                     this.$nextTick(() => this.values = getInitialValue().map(getOptionData).filter(Boolean));
                     this.dispatch('FormItem', 'on-form-change', this.publicValue);
                 }


### PR DESCRIPTION
1.如果labelInValue等于true,那么publicValue的值就是label 和 value 对象，再接下来的else分支判断值是否相等就会错误的判断为不相等，导致重新初始值，覆盖掉了原来的值。
2.重新覆盖值的逻辑是通过getOptionData函数构造数组，但每次从新搜索得到的option集合就回存在和上一次不一样的情况，就会存在丢失原来值的情况
