### PR TITLE
扩展Form，ButtonGroup，RadioGroup，CheckboxGroup添加disabled API，完善＃4881

### DIFF
--- a/src/components/button/button-group.vue
+++ b/src/components/button/button-group.vue
@@ -27,6 +27,10 @@
             vertical: {
                 type: Boolean,
                 default: false
+            },
+            disabled: {
+                type: Boolean,
+                default: false
             }
         },
         computed: {

--- a/src/components/button/button.vue
+++ b/src/components/button/button.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="tagName" :class="classes" :disabled="disabled" @click="handleClickLink" v-bind="tagProps">
+    <component :is="tagName" :class="classes" :disabled="isDisabled" @click="handleClickLink" v-bind="tagProps">
         <Icon class="ivu-load-loop" type="ios-loading" v-if="loading"></Icon>
         <Icon :type="icon" :custom="customIcon" v-if="(icon || customIcon) && !loading"></Icon>
         <span v-if="showSlot" ref="slot"><slot></slot></span>
@@ -7,7 +7,7 @@
 </template>
 <script>
     import Icon from '../icon';
-    import { oneOf } from '../../utils/assist';
+    import { findComponentUpward, oneOf } from '../../utils/assist';
     import mixinsLink from '../../mixins/link';
 
     const prefixCls = 'ivu-btn';
@@ -15,6 +15,11 @@
     export default {
         name: 'Button',
         mixins: [ mixinsLink ],
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         components: { Icon },
         props: {
             type: {
@@ -63,7 +68,8 @@
         },
         data () {
             return {
-                showSlot: true
+                showSlot: true,
+                parent: findComponentUpward(this, 'ButtonGroup')
             };
         },
         computed: {
@@ -99,6 +105,11 @@
                     const {htmlType} = this;
                     return {type: htmlType};
                 }
+            },
+            isDisabled () {
+                return this.parent
+                    ? this.parent.disabled || this.disabled || (this.form || {}).disabled
+                    : this.disabled || (this.form || {}).disabled;
             }
         },
         methods: {

--- a/src/components/checkbox/checkbox-group.vue
+++ b/src/components/checkbox/checkbox-group.vue
@@ -26,6 +26,10 @@
                 default () {
                     return !this.$IVIEW || this.$IVIEW.size === '' ? 'default' : this.$IVIEW.size;
                 }
+            },
+            disabled: {
+                type: Boolean,
+                default: false
             }
         },
         data () {

--- a/src/components/checkbox/checkbox.vue
+++ b/src/components/checkbox/checkbox.vue
@@ -6,7 +6,7 @@
                 v-if="group"
                 type="checkbox"
                 :class="inputClasses"
-                :disabled="disabled"
+                :disabled="isDisabled"
                 :value="label"
                 v-model="model"
                 :name="name"
@@ -17,7 +17,7 @@
                 v-else
                 type="checkbox"
                 :class="inputClasses"
-                :disabled="disabled"
+                :disabled="isDisabled"
                 :checked="currentValue"
                 :name="name"
                 @change="change"
@@ -36,6 +36,11 @@
     export default {
         name: 'Checkbox',
         mixins: [ Emitter ],
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         props: {
             disabled: {
                 type: Boolean,
@@ -89,7 +94,7 @@
                     {
                         [`${prefixCls}-group-item`]: this.group,
                         [`${prefixCls}-wrapper-checked`]: this.currentValue,
-                        [`${prefixCls}-wrapper-disabled`]: this.disabled,
+                        [`${prefixCls}-wrapper-disabled`]: this.isDisabled,
                         [`${prefixCls}-${this.size}`]: !!this.size
                     }
                 ];
@@ -99,7 +104,7 @@
                     `${prefixCls}`,
                     {
                         [`${prefixCls}-checked`]: this.currentValue,
-                        [`${prefixCls}-disabled`]: this.disabled,
+                        [`${prefixCls}-disabled`]: this.isDisabled,
                         [`${prefixCls}-indeterminate`]: this.indeterminate
                     }
                 ];
@@ -114,6 +119,11 @@
             },
             inputClasses () {
                 return `${prefixCls}-input`;
+            },
+            isDisabled (){
+                return this.parent
+                ? this.parent.disabled || this.disabled || (this.form).disabled
+                : this.disabled || (this.form).disabled;
             }
         },
         mounted () {

--- a/src/components/color-picker/color-picker.vue
+++ b/src/components/color-picker/color-picker.vue
@@ -13,7 +13,7 @@
             <Icon :type="arrowType" :custom="customArrowType" :size="arrowSize" :class="arrowClasses"></Icon>
             <div
                 ref="input"
-                :tabindex="disabled ? undefined : 0"
+                :tabindex="isDisabled ? undefined : 0"
                 :class="inputClasses"
                 @keydown.tab="onTab"
                 @keydown.esc="onEscape"
@@ -140,6 +140,12 @@ export default {
     directives: {clickOutside, TransferDom},
 
     mixins: [Emitter, Locale, Prefixes],
+
+    inject: {
+        form: {
+            default: ''
+        }
+    },
 
     props: {
         value: {
@@ -292,7 +298,7 @@ export default {
                 `${this.inputPrefixCls}-wrapper`,
                 `${this.inputPrefixCls}-wrapper-${this.size}`,
                 {
-                    [`${this.prefixCls}-disabled`]: this.disabled,
+                    [`${this.prefixCls}-disabled`]: this.isDisabled,
                 },
             ];
         },
@@ -303,7 +309,7 @@ export default {
                 `${this.inputPrefixCls}-${this.size}`,
                 {
                     [`${this.prefixCls}-focused`]: this.visible,
-                    [`${this.prefixCls}-disabled`]: this.disabled,
+                    [`${this.prefixCls}-disabled`]: this.isDisabled,
                 },
             ];
         },
@@ -386,6 +392,9 @@ export default {
                 }
             }
             return size;
+        },
+        isDisabled () {
+            return this.disabled || (this.form || {}).disabled;
         }
     },
 
@@ -430,7 +439,7 @@ export default {
             this.visible = false;
         },
         toggleVisible() {
-            if (this.disabled) {
+            if (this.isDisabled) {
                 return;
             }
 

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -12,7 +12,7 @@
                     :element-id="elementId"
                     :class="[prefixCls + '-editor']"
                     :readonly="!editable || readonly"
-                    :disabled="disabled"
+                    :disabled="isDisabled"
                     :size="size"
                     :placeholder="placeholder"
                     :value="visualValue"
@@ -122,6 +122,11 @@
     export default {
         mixins: [ Emitter ],
         components: { iInput, Drop, Icon },
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         directives: { clickOutside, TransferDom },
         props: {
             format: {
@@ -351,6 +356,9 @@
                 }
 
                 return size;
+            },
+            isDisabled() {
+                return this.disabled || (this.form || {}).disabled;
             }
         },
         methods: {
@@ -393,7 +401,7 @@
                 if (this.readonly) return;
                 this.isFocused = true;
                 if (e && e.type === 'focus') return; // just focus, don't open yet
-                if(!this.disabled){
+                if(!this.isDisabled){
                     this.visible = true;
                 }
             },
@@ -635,7 +643,7 @@
                 }
             },
             handleInputMouseenter () {
-                if (this.readonly || this.disabled) return;
+                if (this.readonly || this.isDisabled) return;
                 if (this.visualValue && this.clearable) {
                     this.showClose = true;
                 }
@@ -647,7 +655,7 @@
                 if (this.showClose) {
                     if (e) e.stopPropagation();
                     this.handleClear();
-                } else if (!this.disabled) {
+                } else if (!this.isDisabled) {
                     this.handleFocus();
                 }
             },

--- a/src/components/form/form.vue
+++ b/src/components/form/form.vue
@@ -37,6 +37,10 @@
                     return oneOf(value, ['on', 'off']);
                 },
                 default: 'off'
+            },
+            disabled: {
+                type: Boolean,
+                default: false
             }
         },
         provide() {

--- a/src/components/input/input.vue
+++ b/src/components/input/input.vue
@@ -2,7 +2,7 @@
     <div :class="wrapClasses">
         <template v-if="type !== 'textarea'">
             <div :class="[prefixCls + '-group-prepend']" v-if="prepend" v-show="slotReady"><slot name="prepend"></slot></div>
-            <i class="ivu-icon" :class="['ivu-icon-ios-close-circle', prefixCls + '-icon', prefixCls + '-icon-clear' , prefixCls + '-icon-normal']" v-if="clearable && currentValue && !disabled" @click="handleClear"></i>
+            <i class="ivu-icon" :class="['ivu-icon-ios-close-circle', prefixCls + '-icon', prefixCls + '-icon-clear' , prefixCls + '-icon-normal']" v-if="clearable && currentValue && !isDisabled" @click="handleClear"></i>
             <i class="ivu-icon" :class="['ivu-icon-' + icon, prefixCls + '-icon', prefixCls + '-icon-normal']" v-else-if="icon" @click="handleIconClick"></i>
             <i class="ivu-icon ivu-icon-ios-search" :class="[prefixCls + '-icon', prefixCls + '-icon-normal', prefixCls + '-search-icon']" v-else-if="search && enterButton === false" @click="handleSearch"></i>
             <span class="ivu-input-suffix" v-else-if="showSuffix"><slot name="suffix"><i class="ivu-icon" :class="['ivu-icon-' + suffix]" v-if="suffix"></i></slot></span>
@@ -17,7 +17,7 @@
                 :type="type"
                 :class="inputClasses"
                 :placeholder="placeholder"
-                :disabled="disabled"
+                :disabled="isDisabled"
                 :maxlength="maxlength"
                 :readonly="readonly"
                 :name="name"
@@ -52,7 +52,7 @@
             :class="textareaClasses"
             :style="textareaStyles"
             :placeholder="placeholder"
-            :disabled="disabled"
+            :disabled="isDisabled"
             :rows="rows"
             :maxlength="maxlength"
             :readonly="readonly"
@@ -82,6 +82,11 @@
     export default {
         name: 'Input',
         mixins: [ Emitter ],
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         props: {
             type: {
                 validator (value) {
@@ -208,7 +213,7 @@
                     `${prefixCls}`,
                     {
                         [`${prefixCls}-${this.size}`]: !!this.size,
-                        [`${prefixCls}-disabled`]: this.disabled,
+                        [`${prefixCls}-disabled`]: this.isDisabled,
                         [`${prefixCls}-with-prefix`]: this.showPrefix,
                         [`${prefixCls}-with-suffix`]: this.showSuffix || (this.search && this.enterButton === false)
                     }
@@ -218,9 +223,12 @@
                 return [
                     `${prefixCls}`,
                     {
-                        [`${prefixCls}-disabled`]: this.disabled
+                        [`${prefixCls}-disabled`]: this.isDisabled
                     }
                 ];
+            },
+            isDisabled () {
+                return this.disabled || (this.form || {}).disabled;
             }
         },
         methods: {

--- a/src/components/radio/radio-group.vue
+++ b/src/components/radio/radio-group.vue
@@ -41,6 +41,10 @@
             name: {
                 type: String,
                 default: getUuid
+            },
+            disabled: {
+                type: Boolean,
+                default: false
             }
         },
         data () {

--- a/src/components/radio/radio.vue
+++ b/src/components/radio/radio.vue
@@ -5,7 +5,7 @@
             <input
                 type="radio"
                 :class="inputClasses"
-                :disabled="disabled"
+                :disabled="isDisabled"
                 :checked="currentValue"
                 :name="groupName"
                 @change="change"
@@ -23,6 +23,11 @@
     export default {
         name: 'Radio',
         mixins: [ Emitter ],
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         props: {
             value: {
                 type: [String, Number, Boolean],
@@ -72,7 +77,7 @@
                     {
                         [`${prefixCls}-group-item`]: this.group,
                         [`${prefixCls}-wrapper-checked`]: this.currentValue,
-                        [`${prefixCls}-wrapper-disabled`]: this.disabled,
+                        [`${prefixCls}-wrapper-disabled`]: this.isDisabled,
                         [`${prefixCls}-${this.size}`]: !!this.size,
                         [`${prefixCls}-focus`]: this.focusWrapper
                     }
@@ -83,7 +88,7 @@
                     `${prefixCls}`,
                     {
                         [`${prefixCls}-checked`]: this.currentValue,
-                        [`${prefixCls}-disabled`]: this.disabled
+                        [`${prefixCls}-disabled`]: this.isDisabled
                     }
                 ];
             },
@@ -97,6 +102,11 @@
             },
             inputClasses () {
                 return `${prefixCls}-input`;
+            },
+            isDisabled () {
+                return this.parent
+                ? this.parent.disabled || this.disabled || (this.form || {}).disabled
+                : this.disabled || (this.form || {}).disabled;
             }
         },
         mounted () {
@@ -109,7 +119,7 @@
                     }
                     /* eslint-enable no-console */
                 } else {
-                    this.groupName = this.parent.name; 
+                    this.groupName = this.parent.name;
                 }
             }
 
@@ -121,7 +131,7 @@
         },
         methods: {
             change (event) {
-                if (this.disabled) {
+                if (this.isDisabled) {
                     return false;
                 }
 

--- a/src/components/rate/rate.vue
+++ b/src/components/rate/rate.vue
@@ -37,6 +37,11 @@
     export default {
         name: 'Rate',
         mixins: [ Locale, Emitter ],
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         components: { Icon },
         props: {
             count: {
@@ -93,7 +98,7 @@
                 return [
                     `${prefixCls}`,
                     {
-                        [`${prefixCls}-disabled`]: this.disabled
+                        [`${prefixCls}-disabled`]: this.isDisabled
                     }
                 ];
             },
@@ -108,6 +113,9 @@
             },
             showCharacter () {
                 return this.character !== '' || this.icon !== '' || this.customIcon !== '';
+            },
+            isDisabled () {
+                return this.disabled || (this.form || {}).disabled;
             }
         },
         watch: {
@@ -135,7 +143,7 @@
                 }
 
                 return [
-                    {   
+                    {
                         [`${prefixCls}-star`]: !this.showCharacter,
                         [`${prefixCls}-star-chart`]: this.showCharacter,
                         [`${prefixCls}-star-full`]: (!isLast && full) || (isLast && !this.isHalf),
@@ -145,7 +153,7 @@
                 ];
             },
             handleMousemove(value, event) {
-                if (this.disabled) return;
+                if (this.isDisabled) return;
 
                 this.isHover = true;
                 if (this.allowHalf) {
@@ -157,7 +165,7 @@
                 this.hoverIndex = value;
             },
             handleMouseleave () {
-                if (this.disabled) return;
+                if (this.isDisabled) return;
 
                 this.isHover = false;
                 this.setHalf(this.currentValue);
@@ -167,7 +175,7 @@
                 this.isHalf = this.allowHalf && val.toString().indexOf('.') >= 0;
             },
             handleClick (value) {
-                if (this.disabled) return;
+                if (this.isDisabled) return;
                 //value++;
                 if (this.isHalf) value -= 0.5;
 

--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -35,7 +35,7 @@
                     :values="values"
                     :clearable="canBeCleared"
                     :prefix="prefix"
-                    :disabled="disabled"
+                    :disabled="isDisabled"
                     :remote="remote"
                     :input-element-id="elementId"
                     :initial-label="initialLabel"
@@ -157,6 +157,11 @@
         name: 'iSelect',
         mixins: [ Emitter, Locale ],
         components: { FunctionalOptions, Drop, SelectHead },
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         directives: { clickOutside, TransferDom },
         props: {
             value: {
@@ -294,7 +299,7 @@
                     `${prefixCls}`,
                     {
                         [`${prefixCls}-visible`]: this.visible,
-                        [`${prefixCls}-disabled`]: this.disabled,
+                        [`${prefixCls}-disabled`]: this.isDisabled,
                         [`${prefixCls}-multiple`]: this.multiple,
                         [`${prefixCls}-single`]: !this.multiple,
                         [`${prefixCls}-show-clear`]: this.showCloseIcon,
@@ -355,7 +360,7 @@
             },
             canBeCleared(){
                 const uiStateMatch = this.hasMouseHoverHead || this.active;
-                const qualifiesForClear = !this.multiple && !this.disabled && this.clearable;
+                const qualifiesForClear = !this.multiple && !this.isDisabled && this.clearable;
                 return uiStateMatch && qualifiesForClear && this.reset; // we return a function
             },
             selectOptions() {
@@ -422,10 +427,13 @@
                 return extractOptions(this.selectOptions);
             },
             selectTabindex(){
-                return this.disabled || this.filterable ? -1 : 0;
+                return this.isDisabled || this.filterable ? -1 : 0;
             },
             remote(){
                 return typeof this.remoteMethod === 'function';
+            },
+            isDisabled () {
+                return this.disabled || (this.form || {}).disabled;
             }
         },
         methods: {
@@ -502,7 +510,7 @@
             },
 
             toggleMenu (e, force) {
-                if (this.disabled) {
+                if (this.isDisabled) {
                     return false;
                 }
 
@@ -685,7 +693,7 @@
                 this.filterQueryChange = true;
             },
             toggleHeaderFocus({type}){
-                if (this.disabled) {
+                if (this.isDisabled) {
                     return;
                 }
                 this.isFocused = type === 'focus';

--- a/src/components/slider/slider.vue
+++ b/src/components/slider/slider.vue
@@ -7,7 +7,7 @@
             :max="max"
             :step="step"
             :value="exportValue[0]"
-            :disabled="disabled"
+            :disabled="isDisabled"
             :active-change="activeChange"
             @on-change="handleInputChange"></Input-number>
         <div
@@ -93,6 +93,7 @@
     export default {
         name: 'Slider',
         mixins: [ Emitter ],
+        inject: ['form'],
         components: { InputNumber, Tooltip },
         props: {
             min: {
@@ -200,7 +201,7 @@
                     {
                         [`${prefixCls}-input`]: this.showInput && !this.range,
                         [`${prefixCls}-range`]: this.range,
-                        [`${prefixCls}-disabled`]: this.disabled
+                        [`${prefixCls}-disabled`]: this.isDisabled
                     }
                 ];
             },
@@ -265,6 +266,9 @@
             },
             secondPosition () {
                 return this.currentValue[1];
+            },
+            isDisabled () {
+                return this.disabled || (this.form || {}).disabled;
             }
         },
         methods: {
@@ -280,7 +284,7 @@
                 return [min, max];
             },
             getCurrentValue (event, type) {
-                if (this.disabled) {
+                if (this.isDisabled) {
                     return;
                 }
 
@@ -304,7 +308,7 @@
                 }
             },
             onPointerDown (event, type) {
-                if (this.disabled) return;
+                if (this.isDisabled) return;
                 event.preventDefault();
                 this.pointerDown = type;
 
@@ -386,7 +390,7 @@
             },
 
             sliderClick (event) {
-                if (this.disabled) return;
+                if (this.isDisabled) return;
                 const currentX = this.getPointerX(event);
                 const sliderOffsetLeft = this.$refs.slider.getBoundingClientRect().left;
                 let newPos = ((currentX - sliderOffsetLeft) / this.sliderWidth * this.valueRange) + this.min;

--- a/src/components/switch/switch.vue
+++ b/src/components/switch/switch.vue
@@ -21,6 +21,11 @@
     export default {
         name: 'iSwitch',
         mixins: [ Emitter ],
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         props: {
             value: {
                 type: [String, Number, Boolean],
@@ -65,7 +70,7 @@
                     `${prefixCls}`,
                     {
                         [`${prefixCls}-checked`]: this.currentValue === this.trueValue,
-                        [`${prefixCls}-disabled`]: this.disabled,
+                        [`${prefixCls}-disabled`]: this.isDisabled,
                         [`${prefixCls}-${this.size}`]: !!this.size,
                         [`${prefixCls}-loading`]: this.loading,
                     }
@@ -73,12 +78,15 @@
             },
             innerClasses () {
                 return `${prefixCls}-inner`;
+            },
+            isDisabled () {
+                return this.disabled || (this.form || {}).disabled;
             }
         },
         methods: {
             toggle (event) {
                 event.preventDefault();
-                if (this.disabled || this.loading) {
+                if (this.isDisabled || this.loading) {
                     return false;
                 }
 

--- a/src/components/upload/upload.vue
+++ b/src/components/upload/upload.vue
@@ -35,6 +35,11 @@
     export default {
         name: 'Upload',
         mixins: [ Emitter ],
+        inject: {
+            form: {
+                default: ''
+            }
+        },
         components: { UploadList },
         props: {
             action: {
@@ -162,11 +167,13 @@
                     }
                 ];
             },
-
+            isDisabled () {
+                return this.disabled || (this.form || {}).disabled;
+            }
         },
         methods: {
             handleClick () {
-                if (this.disabled) return;
+                if (this.isDisabled) return;
                 this.$refs.input.click();
             },
             handleChange (e) {
@@ -180,11 +187,11 @@
             },
             onDrop (e) {
                 this.dragOver = false;
-                if (this.disabled) return;
+                if (this.isDisabled) return;
                 this.uploadFiles(e.dataTransfer.files);
             },
             handlePaste (e) {
-                if (this.disabled) return;
+                if (this.isDisabled) return;
                 if (this.paste) {
                     this.uploadFiles(e.clipboardData.files);
                 }

--- a/types/button.d.ts
+++ b/types/button.d.ts
@@ -88,4 +88,9 @@ export declare class ButtonGroup extends Vue {
    * @default false
    */
   vertical?: boolean;
+  /**
+   * 设置按钮为禁用状态
+   * @default false
+   */
+  disabled?: boolean;
 }

--- a/types/checkbox.d.ts
+++ b/types/checkbox.d.ts
@@ -55,6 +55,11 @@ export declare class CheckboxGroup extends Vue {
    */
   size?: '' | 'large' | 'small' | 'default';
   /**
+   * 设置复选框禁用状态
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * 在选项状态发生改变时触发，返回已选中的数组。通过修改外部的数据改变时不会触发
    */
   $emit(eventName: 'on-change', values: Array<string | number | boolean>): this;

--- a/types/form.d.ts
+++ b/types/form.d.ts
@@ -19,6 +19,11 @@ export declare class Form extends Vue {
    */
   inline?: boolean;
   /**
+   * 设置表单禁用状态
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * 表单域标签的位置，可选值为 left、right、top
    * @default right
    */

--- a/types/radio.d.ts
+++ b/types/radio.d.ts
@@ -58,6 +58,11 @@ export declare class RadioGroup extends Vue {
    */
   vertical?: boolean;
   /**
+   * 设置单选框禁用状态
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * 在选项状态发生改变时触发，返回当前选中的项。通过修改外部的数据改变时不会触发
    */
   $emit(eventName: 'on-change', ...args: Array<string | number | boolean>): this;


### PR DESCRIPTION
add: form,button-group,checkbox-group,radio-group disabled api; fix: butto, button-group,checkbox,checkbox-group,color-picker,form,input,radio,radio-group,rate,select,slider,switch,upload

examples:
```
<Form disabled>...</Form>
<ButtonGroup disabled></ButtonGroup>
<CheckboxGroup disabled></CheckboxGroup>
<RadioGroup disabled></RadioGroup>
```

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
