### PR TITLE
feat: Add support for customizing submenu expand and collapse delay

### DIFF
--- a/src/components/menu/submenu.vue
+++ b/src/components/menu/submenu.vue
@@ -110,6 +110,42 @@
                     }
                 }
                 return size;
+            },
+            // global setting
+            submenuExpandDelay () {
+                let delay = '';
+
+                if (this.$IVIEW) {
+                    if (this.$IVIEW.menu.submenuExpandDelay) {
+                        delay = this.$IVIEW.menu.submenuExpandDelay;
+                    }
+                }
+
+                let delayMillis = parseInt(delay);
+                if (isNaN(delayMillis)) {
+                    // Print warn here if delay is not '' ?
+                    delayMillis = 250;
+                }
+
+                return delayMillis;
+            },
+            // global setting
+            submenuCollapseDelay () {
+                let delay = '';
+
+                if (this.$IVIEW) {
+                    if (this.$IVIEW.menu.submenuCollapseDelay) {
+                        delay = this.$IVIEW.menu.submenuCollapseDelay;
+                    }
+                }
+
+                let delayMillis = parseInt(delay);
+                if (isNaN(delayMillis)) {
+                    // Print warn here if delay is not '' ?
+                    delayMillis = 150;
+                }
+
+                return delayMillis;
             }
         },
         methods: {
@@ -121,7 +157,7 @@
                 this.timeout = setTimeout(() => {
                     this.menu.updateOpenKeys(this.name);
                     this.opened = true;
-                }, 250);
+                }, this.submenuExpandDelay);
             },
             handleMouseleave () {
                 if (this.disabled) return;
@@ -131,7 +167,7 @@
                 this.timeout = setTimeout(() => {
                     this.menu.updateOpenKeys(this.name);
                     this.opened = false;
-                }, 150);
+                }, this.submenuCollapseDelay);
             },
             handleClick () {
                 if (this.disabled) return;

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,9 @@ const install = function(Vue, opts = {}) {
         menu: {
             arrow: opts.menu ? opts.menu.arrow ? opts.menu.arrow : '' : '',
             customArrow: opts.menu ? opts.menu.customArrow ? opts.menu.customArrow : '' : '',
-            arrowSize: opts.menu ? opts.menu.arrowSize ? opts.menu.arrowSize : '' : ''
+            arrowSize: opts.menu ? opts.menu.arrowSize ? opts.menu.arrowSize : '' : '',
+            submenuExpandDelay: opts.menu ? opts.menu.submenuExpandDelay ? opts.menu.submenuExpandDelay : '' : '',
+            submenuCollapseDelay: opts.menu ? opts.menu.submenuCollapseDelay ? opts.menu.submenuCollapseDelay : '' : ''
         },
         tree: {
             arrow: opts.tree ? opts.tree.arrow ? opts.tree.arrow : '' : '',

--- a/types/iview.components.d.ts
+++ b/types/iview.components.d.ts
@@ -80,6 +80,8 @@ interface IViewGlobalOptions{
         arrow: string;
         customArrow: string;
         arrowSize: number | string;
+        submenuExpandDelay: number | string;
+        submenuCollapseDelay: number | string;
     };
     tree: {
         arrow: string;


### PR DESCRIPTION
添加一个全局配置，可以让用户自行配置菜单 hover 时的展开与收起的延迟时间。
menu.submenuExpandDelay: Menu 展开延迟时间（以毫秒为单位，默认 250）
menu.submenuCollapseDelay: Menu 收起延迟时间（以毫秒为单位，默认 150）

配置 `menu: { submenuExpandDelay: 70 }` 时的效果：
![pXWvIH99VX](https://user-images.githubusercontent.com/6198193/59317745-dda60800-8cf6-11e9-97d5-7e7102e82879.gif)
