### PR TITLE
Pass the name of the Panel clicked in Collapse.

### DIFF
--- a/src/components/collapse/collapse.vue
+++ b/src/components/collapse/collapse.vue
@@ -95,7 +95,7 @@
 
                 this.currentValue = newActiveKey;
                 this.$emit('input', newActiveKey);
-                this.$emit('on-change', newActiveKey);
+                this.$emit('on-change', newActiveKey, name);
             }
         },
         watch: {


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
Sometimes I really want to know which "Panel" I clicked in "Collapse", so I passed "name" in the "on-change" event. 
 Even though I can get the "name" by comparing "Collapse"'s values ​​before and after the change, I prefer to simply pass it out.
