### PR TITLE
解决defaultFileList在不是数组时，map方法报错。

### DIFF
--- a/src/components/upload/upload.vue
+++ b/src/components/upload/upload.vue
@@ -332,6 +332,9 @@
             defaultFileList: {
                 immediate: true,
                 handler(fileList) {
+                    if (!Array.isArray(fileList)) {
+                        fileList = []
+                    }
                     this.fileList = fileList.map(item => {
                         item.status = 'finished';
                         item.percentage = 100;


### PR DESCRIPTION
解决defaultFileList在不是数组时，map方法报错

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
