### PR TITLE
上传文件列表删除文件时触发on-form-change事件

### DIFF
--- a/src/components/upload/upload.vue
+++ b/src/components/upload/upload.vue
@@ -318,6 +318,7 @@
                 const fileList = this.fileList;
                 fileList.splice(fileList.indexOf(file), 1);
                 this.onRemove(file, fileList);
+                this.dispatch('FormItem', 'on-form-change', file, fileList);
             },
             handlePreview(file) {
                 if (file.status === 'finished') {


### PR DESCRIPTION
删除上传文件列表时，理论上最好也分发on-form-change消息，这样可以配合表单验证的需要(对比上传成功时onSuccess方法)。比如考虑以下场景，当设置了upload组件的form-item的validator为required，在上传文件列表删除为空时，可以自动校验并提示用户必须有文件上传。
