### PR TITLE
fix#5925

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -707,6 +707,10 @@
 
                 if (value === '') this.values = [];
                 else if (checkValuesNotEqual(value,publicValue,values)) {
+                    this.focusIndex = this.flatOptions.findIndex((opt) => {
+                        if (!opt || !opt.componentOptions) return false;
+                        return opt.componentOptions.propsData.value === value;
+                    });
                     this.$nextTick(() => this.values = getInitialValue().map(getOptionData).filter(Boolean));
                     this.dispatch('FormItem', 'on-form-change', this.publicValue);
                 }


### PR DESCRIPTION
详见https://github.com/iview/iview/issues/5925
select组件value值被外部修改 focusIndex未及时更新 导致ivu-select-item-focus和ivu-select-item-selected不在同一个option