### PR TITLE
Fix #5748

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -258,7 +258,7 @@
             this.$on('on-select-selected', this.onOptionClick);
 
             // set the initial values if there are any
-            if (!this.remote && this.selectOptions.length > 0){
+            if (this.selectOptions.length > 0){
                 this.values = this.getInitialValue().map(value => {
                     if (typeof value !== 'number' && !value) return null;
                     return this.getOptionData(value);


### PR DESCRIPTION
失去焦点后会执行select-head.vue中onInputBlur事件[1]，事件中会判断当前下拉没有值就清空输入框，而在select.vue的mounted初始化值时排除了remote模式，导致remote模式没有赋上初始化值，离开文本框后默认值被onInputBlur事件清空了。

[1]
```
onInputBlur () {
     if (!this.values.length) this.query = '';  // #5155
     this.$emit('on-input-blur');
 }
```
