### PR TITLE
Update transfer.vue

### DIFF
--- a/src/components/transfer/transfer.vue
+++ b/src/components/transfer/transfer.vue
@@ -133,7 +133,7 @@
                 type: Function,
                 default (data, query) {
                     const type = ('label' in data) ? 'label' : 'key';
-                    return data[type].indexOf(query) > -1;
+                    return (data[type]+'').indexOf(query) > -1;
                 }
             },
             notFoundText: {


### PR DESCRIPTION
when key's value type is not String, will cause exception when Transfer component mounted

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
