### PR TITLE
fixed: 级联组件data中value类型非字符串时，筛选时无法选中筛选的项

### DIFF
--- a/src/components/cascader/cascader.vue
+++ b/src/components/cascader/cascader.vue
@@ -207,7 +207,7 @@
                     for (let i = 0; i < arr.length; i++) {
                         let item = arr[i];
                         item.__label = label ? label + ' / ' + item.label : item.label;
-                        item.__value = value ? value + ',' + item.value : item.value;
+                        item.__value = value ? [...value, item.value] : [item.value];
 
                         if (item.children && item.children.length) {
                             getSelections(item.children, item.__label, item.__value);
@@ -276,7 +276,7 @@
                 this.currentValue = this.selected = this.tmpSelected = [];
                 this.handleClose();
                 this.emitValue(this.currentValue, oldVal);
-//                this.$broadcast('on-clear');
+            //                this.$broadcast('on-clear');
                 this.broadcast('Caspanel', 'on-clear');
             },
             handleClose () {
@@ -328,7 +328,7 @@
                 this.query = '';
                 this.$refs.input.currentValue = '';
                 const oldVal = JSON.stringify(this.currentValue);
-                this.currentValue = item.value.split(',');
+                this.currentValue = item.value;
                 // use setTimeout for #4786, can not use nextTick, because @on-find-selected use nextTick
                 setTimeout(() => {
                     this.emitValue(this.currentValue, oldVal);


### PR DESCRIPTION
造成这个bug的原因是筛选时value会拼接字符串，选中时再拆分字符串，如果为非字符串类型，拆分前后值类型改变导致无法选中

Close #6259 