### PR TITLE
[Modal] Add `on-closing`, `on-closed`, `on-opened` and `on-opening` events

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -4,7 +4,7 @@
             <div :class="maskClasses" :style="wrapStyles" v-show="visible" v-if="showMask" @click="handleMask"></div>
         </transition>
         <div :class="wrapClasses" :style="wrapStyles" @click="handleWrapClick">
-            <transition :name="transitionNames[0]" @after-leave="animationFinish">
+            <transition :name="transitionNames[0]" @after-leave="animationFinish" @before-enter="$emit('on-opening') @after-enter="$emit('on-opened')" @before-leave="$emit('on-closing')">
                 <div :class="classes" :style="mainStyles" v-show="visible" @mousedown="handleMousedown">
                     <div :class="contentClasses" ref="content" :style="contentStyles" @click="handleClickModal">
                         <a :class="[prefixCls + '-close']" v-if="closable" @click="close">
@@ -289,6 +289,7 @@
             },
             animationFinish() {
                 this.$emit('on-hidden');
+                this.$emit('on-closed');
             },
             handleMoveStart (event) {
                 if (!this.draggable) return false;


### PR DESCRIPTION
These events are extremely helpful in many situations. 

For example, users may want to clear a form or reset the states in a modal before the opening animation and make ajax request before the closing animation.
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
