### PR TITLE
[建议]事件执行由用户决定

### DIFF
--- a/src/components/affix/affix.vue
+++ b/src/components/affix/affix.vue
@@ -48,6 +48,10 @@
             },
             offsetBottom: {
                 type: Number
+            },
+            useCapture: {
+                type: Boolean,
+                default: false
             }
         },
         data () {
@@ -78,8 +82,8 @@
         mounted () {
 //            window.addEventListener('scroll', this.handleScroll, false);
 //            window.addEventListener('resize', this.handleScroll, false);
-            on(window, 'scroll', this.handleScroll);
-            on(window, 'resize', this.handleScroll);
+            on(window, 'scroll', this.handleScroll, this.useCapture);
+            on(window, 'resize', this.handleScroll, this.useCapture);
             this.$nextTick(() => {
                 this.handleScroll();
             });
@@ -87,8 +91,8 @@
         beforeDestroy () {
 //            window.removeEventListener('scroll', this.handleScroll, false);
 //            window.removeEventListener('resize', this.handleScroll, false);
-            off(window, 'scroll', this.handleScroll);
-            off(window, 'resize', this.handleScroll);
+            off(window, 'scroll', this.handleScroll, this.useCapture);
+            off(window, 'resize', this.handleScroll, this.useCapture);
         },
         methods: {
             handleScroll () {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -4,9 +4,9 @@ const isServer = Vue.prototype.$isServer;
 /* istanbul ignore next */
 export const on = (function() {
     if (!isServer && document.addEventListener) {
-        return function(element, event, handler) {
+        return function(element, event, handler, useCapture = false) {
             if (element && event && handler) {
-                element.addEventListener(event, handler, false);
+                element.addEventListener(event, handler, useCapture);
             }
         };
     } else {
@@ -21,9 +21,9 @@ export const on = (function() {
 /* istanbul ignore next */
 export const off = (function() {
     if (!isServer && document.removeEventListener) {
-        return function(element, event, handler) {
+        return function(element, event, handler, useCapture = false) {
             if (element && event) {
-                element.removeEventListener(event, handler, false);
+                element.removeEventListener(event, handler, useCapture);
             }
         };
     } else {


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

问题: 如果<Affix>所在的<Layout>内有滚动条，<Affix>的作用就会失效
原因: <Affix>所加的监听是位于window上，但是鼠标滚轮滚动的是<Layout>的滚动条，并没有触发scroll事件
解决方案: 或许可以将<Affix>里追加监听的时候换成所在的父组件，但个人感觉更好的方式还是将事件执行阶段交由用户决定，追加useCapture参数