### PR TITLE
feat: tabpane添加render

### DIFF
--- a/src/components/tabs/pane.vue
+++ b/src/components/tabs/pane.vue
@@ -1,12 +1,17 @@
 <template>
-    <div :class="prefixCls" v-show="show" :style="contentStyle"><slot></slot></div>
+    <div :class="prefixCls" v-show="show" :style="contentStyle"> 
+        <Render v-if="content && typeof content === 'function'" :render="content"></Render>
+        <slot v-else></slot>
+    </div>
 </template>
 <script>
     const prefixCls = 'ivu-tabs-tabpane';
-
+    import Render from '../base/render';
+    
     export default {
         name: 'TabPane',
         inject: ['TabsInstance'],
+        components: { Render },
         props: {
             name: {
                 type: String
@@ -34,6 +39,10 @@
             // 数值需大于 0
             index: {
                 type: Number
+            },
+            content: {
+                type: [String, Function],
+                default: ''
             }
         },
         data () {


### PR DESCRIPTION
现象： 开发时经常会出现动态渲染tabs的情况，需要遍历tab-pane，然而tab-pane 内部的内容常常为引入自定义的组件，只能v-if去控制，数量多时写法很不友好。

解决： 添加render函数, 可以更好的在数据层控制。
