### PR TITLE
Fix message types

### DIFF
--- a/types/message.d.ts
+++ b/types/message.d.ts
@@ -10,26 +10,31 @@ export declare class Message extends Vue {
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
     info(config?: MessageConfig | string): () => void;
+    static info(config?: MessageConfig | string): () => void;
     /**
      * 成功
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
     success(config?: MessageConfig | string): () => void;
+    static success(config?: MessageConfig | string): () => void;
     /**
      * 警告
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
     warning(config?: MessageConfig | string): () => void;
+    static warning(config?: MessageConfig | string): () => void;
     /**
      * 错误
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
     error(config?: MessageConfig | string): () => void;
+    static error(config?: MessageConfig | string): () => void;
     /**
      * 配置
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
     loading(options?: MessageConfig | string): () => void;
+    static loading(config?: MessageConfig | string): () => void;
     /**
      * 配置
      * @param config MessageConfig为相关配置,string为待显示的内容

--- a/types/message.d.ts
+++ b/types/message.d.ts
@@ -9,27 +9,27 @@ export declare class Message extends Vue {
      * 消息
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
-    info(config?: MessageConfig | string): void;
+    info(config?: MessageConfig | string): () => void;
     /**
      * 成功
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
-    success(config?: MessageConfig | string): void;
+    success(config?: MessageConfig | string): () => void;
     /**
      * 警告
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
-    warning(config?: MessageConfig | string): void;
+    warning(config?: MessageConfig | string): () => void;
     /**
      * 错误
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
-    error(config?: MessageConfig | string): void;
+    error(config?: MessageConfig | string): () => void;
     /**
      * 配置
      * @param config MessageConfig为相关配置,string为待显示的内容
      */
-    loading(options?: MessageConfig | string): void;
+    loading(options?: MessageConfig | string): () => void;
     /**
      * 配置
      * @param config MessageConfig为相关配置,string为待显示的内容


### PR DESCRIPTION
<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

1. `Message.info/success / ...` should return a function to close the instance.
2. #5813 Cannot call method directly in this case:  

```ts
import { Message } from 'iview'
Message.success() 
// TS error : Property 'success' does not exist on type 'typeof Message'.ts(2339)
```