### PR TITLE
修改form-item字段必选标识显示问题

### DIFF
--- a/src/components/form/form-item.vue
+++ b/src/components/form/form-item.vue
@@ -153,9 +153,7 @@
                 if (rules.length&&this.required) {
                     return;
                 }else if (rules.length) {
-                    rules.every((rule) => {
-                        this.isRequired = rule.required;
-                    });
+                    this.isRequired = rules.some((rule) => rule.required);
                 }else if (this.required){
                     this.isRequired = this.required;
                 }


### PR DESCRIPTION
当el-form-item存在多条rule，且数组中标记required属性的rule不是第一个元素时，every只执行一次就会默认返回false，导致迭代器停止，isRequired就取不到正确的值。