### PR TITLE
fix: switch width with flex parent

### DIFF
--- a/src/styles/components/switch.less
+++ b/src/styles/components/switch.less
@@ -3,6 +3,7 @@
 .@{switch-prefix-cls} {
     display: inline-block;
     width: 44px;
+    min-width: 44px;
     height: 22px;
     line-height: 20px;
     border-radius: 22px;
@@ -81,6 +82,7 @@
 
     &-small {
         width: 28px;
+        min-width: 28px;
         height: 16px;
         line-height: 14px;
         &:after {
@@ -111,6 +113,7 @@
 
     &-large{
         width: 56px;
+        min-width: 56px;
         &:active:after {
             width: 26px;
         }
@@ -169,7 +172,7 @@
         border-color: @primary-color;
         background-color: @primary-color;
         opacity: .4;
-        
+
         &:after {
             background: #fff;
         }


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

When using <i-switch> under a flex parent (ie. `display: flex`), the width of the switch may be lower than the width specified in the class.

Adding a `min-width` fixes the problem.

I reproduced the bug on the official documentation, editing the dom directly:
<img width="738" alt="Screenshot 2020-10-21 at 12 26 13" src="https://user-images.githubusercontent.com/10612835/96708053-f6b5d300-1398-11eb-9359-23fd54ce5b5d.png">
