### PR TITLE
fix:修复当loadData执行时赋值给item.children为空数组时，无法选中的bug

### DIFF
--- a/examples/routers/cascader.vue
+++ b/examples/routers/cascader.vue
@@ -52,7 +52,7 @@
                     }else if(item.level === 2){
                         item.children=[{label: '故宫3级',value:'gugong3',level: 3}]
                     }
-                    item.loading = false;
+                    this.$delete(item, 'loading');
                     callback();
                 }, 600);
             }


### PR DESCRIPTION
<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
loadData加载出数据之后请将loading属性给删除掉，否则如果加载的children为空数组的时候，会出现当前选项还是个箭头，无法选中的情况，
复现地址：[https://codesandbox.io/embed/vue2-vue-js-example-with-cdn-forked-x7hv5h?fontsize=14&hidenavigation=1&theme=dark](url)
<img width="1514" alt="image" src="https://user-images.githubusercontent.com/68677756/200093796-c1985158-947d-48ae-aa7f-4d356e112cb2.png">
加载完“北京”的选项，由于children数组为空，会出现“北京”选项无法选中的情况