### PR TITLE
Clear event listeners and timers before component unmounts

### DIFF
--- a/src/components/base/notification/notice.vue
+++ b/src/components/base/notification/notice.vue
@@ -167,6 +167,7 @@
         },
         beforeDestroy () {
             this.clearCloseTimer();
+            clearTimeout(this.closeTimer);
         }
     };
 </script>

--- a/src/components/carousel/carousel.vue
+++ b/src/components/carousel/carousel.vue
@@ -331,6 +331,7 @@
         beforeDestroy () {
 //            window.removeEventListener('resize', this.handleResize, false);
             off(window, 'resize', this.handleResize);
+            clearInterval(this.timer);
         }
     };
 </script>

--- a/src/components/color-picker/color-picker.vue
+++ b/src/components/color-picker/color-picker.vue
@@ -403,6 +403,11 @@ export default {
     mounted() {
         this.$on('on-escape-keydown', this.closer);
         this.$on('on-dragging', this.setDragging);
+
+        this.$once('hook:beforeDestroy', () => {
+            this.$off('on-escape-keydown', this.closer);
+            this.$off('on-dragging', this.setDragging);
+        });
     },
 
     methods: {

--- a/src/components/drawer/drawer.vue
+++ b/src/components/drawer/drawer.vue
@@ -260,6 +260,7 @@
             off(document, 'mousemove', this.handleMousemove);
             off(document, 'mouseup', this.handleMouseup);
             this.removeScrollEffect();
+            clearTimeout(this.timer);
         },
         watch: {
             value (val) {

--- a/src/components/form/form-item.vue
+++ b/src/components/form/form-item.vue
@@ -163,6 +163,11 @@
                 this.$off('on-form-change', this.onFieldChange);
                 this.$on('on-form-blur', this.onFieldBlur);
                 this.$on('on-form-change', this.onFieldChange);
+
+                this.$once('hook:beforeDestroy', () => {
+                    this.$off('on-form-blur', this.onFieldBlur);
+                    this.$off('on-form-change', this.onFieldChange);
+                });
             },
             getRules () {
                 let formRules = this.form.rules;

--- a/src/components/poptip/poptip.vue
+++ b/src/components/poptip/poptip.vue
@@ -302,6 +302,7 @@
                 $children.removeEventListener('focus', this.handleFocus, false);
                 $children.removeEventListener('blur', this.handleBlur, false);
             }
+            clearTimeout(this.enterTimer);
         }
     };
 </script>

--- a/src/components/steps/steps.vue
+++ b/src/components/steps/steps.vue
@@ -124,6 +124,11 @@
             this.updateSteps();
             this.$on('append', this.debouncedAppendRemove());
             this.$on('remove', this.debouncedAppendRemove());
+
+            this.$once('hook:beforeDestroy', () => {
+                this.$off('append', this.debouncedAppendRemove());
+                this.$off('remove', this.debouncedAppendRemove());
+            });
         },
         watch: {
             current () {

--- a/src/components/tooltip/tooltip.vue
+++ b/src/components/tooltip/tooltip.vue
@@ -135,6 +135,10 @@
             if (this.always) {
                 this.updatePopper();
             }
+        },
+
+        beforeDestroy() {
+            clearTimeout(this.timeout);
         }
     };
 </script>


### PR DESCRIPTION
Hi 👋 , thank you for this library
We found that some components used event listeners and timing events, but did not remove them before unmounting. This means an accumulation of listeners and timers each time a component is mounted, on top of the previous ones, leading to a memory leak. This PR fixes this issue :) 
