### PR TITLE
feat(table): support keepAlive for expand rows

### DIFF
--- a/src/components/table/table-body.vue
+++ b/src/components/table/table-body.vue
@@ -29,7 +29,10 @@
                         ></table-cell>
                     </td>
                 </table-tr>
-                <tr v-if="rowExpanded(row._index)" :class="{[prefixCls + '-expanded-hidden']: fixed}">
+                <tr
+                    v-if="renderExpandRow(row._index)"
+                    v-show="showExpandRow(row._index)"
+                    :class="{[prefixCls + '-expanded-hidden']: fixed}">
                     <td :colspan="columns.length" :class="prefixCls + '-expanded-cell'">
                         <Expand :key="rowKey ? row._rowKey : index" :row="row" :render="expandRender" :index="row._index"></Expand>
                     </td>
@@ -81,6 +84,16 @@
                     }
                 }
                 return render;
+            },
+            expandColumn () {
+                for (let i = 0; i < this.columns.length; i++) {
+                    const column = this.columns[i];
+                    if (column.type && column.type === 'expand') return column;
+                }
+                return null;
+            },
+            expandKeepAlive () {
+                return !!(this.expandColumn && this.expandColumn.keepAlive);
             }
         },
         methods: {
@@ -92,6 +105,14 @@
             },
             rowExpanded(_index){
                 return this.objData[_index] && this.objData[_index]._isExpanded;
+            },
+            renderExpandRow (_index) {
+                const data = this.objData[_index];
+                if (!data) return false;
+                return this.expandKeepAlive ? (data._isExpanded || data._isExpandKeepAlive) : data._isExpanded;
+            },
+            showExpandRow (_index) {
+                return this.expandKeepAlive ? this.rowExpanded(_index) : true;
             },
             handleMouseIn (_index) {
                 this.$parent.handleMouseIn(_index);

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -212,15 +212,16 @@
         },
         data () {
             const colsWithId = this.makeColumnsId(this.columns);
+            const cloneColumns = this.makeColumns(colsWithId);
             return {
                 ready: false,
                 tableWidth: 0,
                 columnsWidth: {},
                 prefixCls: prefixCls,
                 compiledUids: [],
-                objData: this.makeObjData(),     // checkbox or highlight-row
+                objData: this.makeObjData(cloneColumns),     // checkbox or highlight-row
                 rebuildData: [],    // for sort or filter
-                cloneColumns: this.makeColumns(colsWithId),
+                cloneColumns: cloneColumns,
                 columnRows: this.makeColumnRows(false, colsWithId),
                 leftFixedColumnRows: this.makeColumnRows('left', colsWithId),
                 rightFixedColumnRows: this.makeColumnRows('right', colsWithId),
@@ -379,6 +380,10 @@
             },
             isRightFixed () {
                 return this.columns.some(col => col.fixed && col.fixed === 'right');
+            },
+            expandKeepAlive () {
+                const column = this.getExpandColumn();
+                return !!(column && column.keepAlive);
             }
         },
         methods: {
@@ -566,6 +571,9 @@
                 }
                 const status = !data._isExpanded;
                 this.objData[_index]._isExpanded = status;
+                if (status && this.expandKeepAlive) {
+                    this.objData[_index]._isExpandKeepAlive = true;
+                }
                 this.$emit('on-expand', JSON.parse(JSON.stringify(this.cloneData[_index])), status);
                 
                 if(this.height || this.maxHeight){
@@ -838,8 +846,14 @@
                 this.cloneColumns.forEach(col => data = this.filterData(data, col));
                 return data;
             },
-            makeObjData () {
+            getExpandColumn (columns = this.cloneColumns) {
+                if (!columns || !columns.length) return null;
+                return columns.find(column => column.type === 'expand') || null;
+            },
+            makeObjData (columns = this.cloneColumns) {
                 let data = {};
+                const expandColumn = this.getExpandColumn(columns);
+                const expandKeepAlive = !!(expandColumn && expandColumn.keepAlive);
                 this.data.forEach((row, index) => {
                     const newRow = deepCopy(row);// todo 直接替换
                     newRow._isHover = false;
@@ -858,6 +872,7 @@
                     } else {
                         newRow._isExpanded = false;
                     }
+                    newRow._isExpandKeepAlive = expandKeepAlive && newRow._isExpanded;
                     if (newRow._highlight) {
                         newRow._isHighlight = newRow._highlight;
                     } else {

--- a/test/unit/specs/table.spec.js
+++ b/test/unit/specs/table.spec.js
@@ -1,4 +1,4 @@
-import { createVue, destroyVM } from '../util';
+import { createVue, destroyVM, waitForIt } from '../util';
 import { csvA, csvB } from './assets/table/csvData.js';
 
 const cleanCSV = (str) => str.split('\n').map(s => s.trim()).filter(Boolean).join('\n');
@@ -42,6 +42,68 @@ describe('Table.vue', () => {
       });
     });
 
+  });
+
+  describe('expand keepAlive', () => {
+    it('should keep expanded component instance after collapse and reopen', done => {
+      const ExpandContent = {
+        name: 'ExpandContent',
+        props: {
+          row: Object
+        },
+        mounted() {
+          this.$root.expandMountCount += 1;
+        },
+        render(h) {
+          return h('div', this.row.name);
+        }
+      };
+
+      vm = createVue({
+        components: { ExpandContent },
+        template: '<div><Table :columns="columns" :data="data" ref="table" /></div>',
+        data() {
+          return {
+            expandMountCount: 0,
+            columns: [
+              {
+                type: 'expand',
+                keepAlive: true,
+                render: (h, params) => h(ExpandContent, {
+                  props: {
+                    row: params.row
+                  }
+                })
+              },
+              {
+                title: 'Name',
+                key: 'name'
+              }
+            ],
+            data: [
+              {
+                name: 'iView'
+              }
+            ]
+          };
+        },
+        mounted() {
+          this.$refs.table.toggleExpand(0);
+          this.$nextTick(() => {
+            waitForIt(() => this.expandMountCount === 1, () => {
+              this.$refs.table.toggleExpand(0);
+              this.$nextTick(() => {
+                this.$refs.table.toggleExpand(0);
+                this.$nextTick(() => {
+                  expect(this.expandMountCount).to.equal(1);
+                  done();
+                });
+              });
+            });
+          });
+        }
+      }, true);
+    });
   });
 
 });

--- a/types/table.d.ts
+++ b/types/table.d.ts
@@ -216,6 +216,12 @@ export declare class TableColumn {
      */
     type?: "index" | "selection" | "expand" | "html";
     /**
+     * 仅在 expand 类型列下生效。开启后，展开行内容在收起时不会销毁，
+     * 再次展开会复用上一次的组件实例。
+     * @default false
+     */
+    keepAlive?: boolean;
+    /**
      * 列头显示文字
      * @default #
      */


### PR DESCRIPTION
## Summary
- add a keepAlive option for expand columns
- keep expanded row instances mounted after the first open and switch to show/hide on collapse
- add a regression test covering collapse and reopen behavior

## Testing
- npm run dist:dev
- eslint src/components/table/table.vue src/components/table/table-body.vue test/unit/specs/table.spec.js
- npx -y -p node@20 node ./node_modules/karma/bin/karma start test/unit/karma.conf.js --single-run --browsers ChromeHeadless

Closes #3546